### PR TITLE
Expand AI usage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ scripts/preview --live --ambient-after 6
 
 The control center shows safe Herdr identity, state duration, repository and
 worktree context, plus the Omarchy AI module's normalized Claude, Codex, and
-OpenCode capacity. Header controls use typed daemon actions to focus or launch
-the fixed ChatGPT Desktop and Claude Desktop entries. The Micro control opens a
-read-only virtual projection of the connected device and current agent slots.
+OpenCode capacity. The AI footer shows both reported usage windows, resets,
+plan/freshness state, and bounded today/hour token activity when available.
+Header controls use typed daemon actions to focus or launch the fixed ChatGPT
+Desktop and Claude Desktop entries. The Micro control opens a read-only virtual
+projection of the connected device and current agent slots.
 The upper-right Motion and Screen controls are shared by the command-center
 and Ambient views. Motion snaps the ambient constellation to fixed positions
 and removes perimeter/trail animation; Screen applies a reversible near-black

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,11 @@ capacity, fixed native desktop launch/focus actions, and a read-only Codex
 Micro projection. QML remains presentation-only; cache parsing, socket reads,
 and desktop actions stay in `xeneon-agentd`.
 
+The completed AI-detail follow-up expands that footer with both reported capacity
+windows, reset timing, plan/freshness state, and bounded aggregate today/hour
+token activity. Prompt text, per-model history, credentials, and raw provider
+payloads remain outside the portal protocol.
+
 ## Done criteria
 
 - [x] Rust daemon and QML bridge expose versioned normalized snapshots.
@@ -63,6 +68,8 @@ and desktop actions stay in `xeneon-agentd`.
       actions remain isolated when present.
 - [x] The footer shows normalized Claude, Codex, and OpenCode usage with
       freshness and quota/local-budget semantics.
+- [x] The footer shows both reported windows, reset timing, plan/freshness
+      state, and bounded today/hour token activity without exposing raw data.
 - [x] ChatGPT and Claude buttons focus or launch only their fixed native
       desktop IDs through daemon-owned actions.
 - [x] A right-side read-only Micro drawer shows fresh device status, projected
@@ -82,6 +89,7 @@ and desktop actions stay in `xeneon-agentd`.
 | Live naming, voice, and ambient ring UX | `agent/portal-voice-ring` in `portal-voice-ring` worktree | normalized public protocol fields, `quickshell/`, fixtures, UX docs/tests | Live on the physical EDGE; remaining power/privacy checks are open |
 | Concept motion parity | `agent/portal-voice-ring` in `portal-voice-ring` worktree | ambient presentation, preview timing, visual QA | Live on the physical EDGE; remaining power/privacy checks are open |
 | Agent-command home redesign | `agent/portal-voice-ring` in `portal-voice-ring` worktree | normalized safe metadata, usage/Micro collectors, fixed app actions, control-center QML | Software complete, live-previewed, and independently reviewed |
+| AI usage detail expansion | `main` | bounded usage protocol, AI dock, tests/docs | Complete, installed, and physically verified |
 | Global display controls | `agent/portal-voice-ring` in `portal-voice-ring` worktree | persistent presentation settings, reduced-motion composition, dim veil | Live on the physical EDGE; default full-motion/normal-screen state restored |
 | Omarchy integration | `agent/portal-voice-ring` in `portal-voice-ring` worktree | `config/`, `scripts/`, services, install tests | Production user integration installed and active on the physical EDGE |
 
@@ -189,6 +197,16 @@ and desktop actions stay in `xeneon-agentd`.
 - [x] Agent-command home independent Rust/QML review resolved launch
       coalescing, collector non-blocking behavior, verified Micro identity, and
       fail-closed usage; final re-review found no remaining P0/P1/P2 issues.
+- [x] AI usage detail gate: 53 core plus 1 CLI test, strict fmt/clippy, 25
+      Python contracts/fixtures, 85 Qt tests with `qmllint`, and 25 isolated
+      installer scenarios.
+- [x] AI usage detail physical QA captured the installed native 2560x720 DP-2
+      surface with both available usage windows, reset timing, plan/freshness,
+      explicit provider status, and bounded today/hour token activity; both
+      services remained active with zero restarts.
+- [x] Independent AI usage detail review approved the additive schema-v1
+      fields, trust clearing, Rust/QML bounds, and 1280x360 composition with no
+      substantive findings.
 - [ ] Physical hardware gate (hotplug, DPMS, suspend/resume, privacy,
       guarded-hold behavior, and DDC restore remain).
 
@@ -206,8 +224,12 @@ and desktop actions stay in `xeneon-agentd`.
   automatically cancelled a recording when its bridge client disconnected,
   and restored the prior ChatGPT window before laptop voice actions.
 - `xeneon-agentd.service` and `xeneon-edge-portal.service` are enabled,
-  active, and running without restarts after the persistent presentation
-  settings activation.
+  active, and running without restarts after the reviewed AI usage detail
+  activation.
+- The installed physical footer now shows both reported provider windows,
+  reset timing, plan/freshness and explicit status, plus bounded aggregate
+  today/hour activity when available; no prompts, per-model history,
+  credentials, or raw provider payloads cross the protocol.
 - Portal preferences persist at
   `~/.local/state/xeneon-edge-agents/portal/preferences.ini` with mode `0600`;
   physical validation ended in the default full-motion, normal-screen state.

--- a/crates/xeneon-agent-core/src/model.rs
+++ b/crates/xeneon-agent-core/src/model.rs
@@ -156,6 +156,10 @@ pub struct ProviderUsage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub secondary: Option<UsageWindow>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub today_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens_per_hour: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_updated_ms: Option<u64>,
 }
 

--- a/crates/xeneon-agent-core/src/usage.rs
+++ b/crates/xeneon-agent-core/src/usage.rs
@@ -10,6 +10,7 @@ use crate::model::{AiUsageSnapshot, ProviderUsage, UsageKind, UsageWindow};
 
 const FRESH_FOR: Duration = Duration::from_secs(15 * 60);
 const MAX_CACHE_BYTES: u64 = 64 * 1024;
+const MAX_AGGREGATE_TOKENS: u64 = 1_000_000_000_000_000;
 
 #[derive(Debug, Clone)]
 pub struct UsageCollector {
@@ -72,6 +73,8 @@ impl UsageCollector {
             model: bounded(value.get("_model").and_then(Value::as_str), 80),
             primary: None,
             secondary: None,
+            today_tokens: aggregate_tokens(value.get("_today_tokens")),
+            tokens_per_hour: aggregate_tokens(value.get("_rate_per_hour")),
             last_updated_ms,
         };
 
@@ -88,6 +91,8 @@ impl UsageCollector {
             provider.stale = true;
             provider.primary = None;
             provider.secondary = None;
+            provider.today_tokens = None;
+            provider.tokens_per_hour = None;
         }
         provider
     }
@@ -167,6 +172,14 @@ fn numeric(value: Option<&Value>) -> Option<f64> {
         .filter(|number: &f64| number.is_finite())
 }
 
+fn aggregate_tokens(value: Option<&Value>) -> Option<u64> {
+    let value = numeric(value)?;
+    if !(0.0..=MAX_AGGREGATE_TOKENS as f64).contains(&value) {
+        return None;
+    }
+    Some(value.floor() as u64)
+}
+
 fn bounded(value: Option<&str>, limit: usize) -> Option<String> {
     value
         .map(str::trim)
@@ -221,6 +234,8 @@ fn unavailable_provider(
         model: None,
         primary: None,
         secondary: None,
+        today_tokens: None,
+        tokens_per_hour: None,
         last_updated_ms,
     }
 }
@@ -247,11 +262,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn collector_normalizes_quota_and_local_budget_without_raw_counters() {
+    fn collector_normalizes_capacity_and_bounded_aggregate_activity() {
         let temp = tempfile::tempdir().unwrap();
         fs::write(
             temp.path().join("claude-usage.json"),
-            r#"{"5h-utilization":"0.25","5h-reset":"1800000000","7d-utilization":"0.5","7d-reset":"1800100000","_source":"oauth","status":"allowed","_today_tokens":999}"#,
+            r#"{"5h-utilization":"0.25","5h-reset":"1800000000","7d-utilization":"0.5","7d-reset":"1800100000","_source":"oauth","status":"allowed","_today_tokens":999,"_rate_per_hour":"125.9"}"#,
         )
         .unwrap();
         fs::write(
@@ -277,8 +292,11 @@ mod tests {
         );
         assert_eq!(snapshot.providers[2].kind, UsageKind::LocalBudget);
         assert_eq!(snapshot.providers[2].model.as_deref(), Some("gpt-test"));
+        assert_eq!(snapshot.providers[0].today_tokens, Some(999));
+        assert_eq!(snapshot.providers[0].tokens_per_hour, Some(125));
         let encoded = serde_json::to_string(&snapshot).unwrap();
-        assert!(!encoded.contains("today_tokens"));
+        assert!(encoded.contains("\"today_tokens\":999"));
+        assert!(encoded.contains("\"tokens_per_hour\":125"));
         assert!(!encoded.contains("_models"));
     }
 
@@ -300,7 +318,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         fs::write(
             temp.path().join("claude-usage.json"),
-            r#"{"5h-utilization":"0.25","_source":"oauth","status":"blocked"}"#,
+            r#"{"5h-utilization":"0.25","_source":"oauth","status":"blocked","_today_tokens":123,"_rate_per_hour":45}"#,
         )
         .unwrap();
         fs::write(
@@ -315,10 +333,32 @@ mod tests {
         assert!(!claude.available);
         assert!(claude.stale);
         assert!(claude.primary.is_none());
+        assert_eq!(claude.today_tokens, None);
+        assert_eq!(claude.tokens_per_hour, None);
         let codex = &snapshot.providers[1];
         assert_eq!(codex.source, "unknown");
         assert!(!codex.available);
         assert!(codex.stale);
         assert!(codex.primary.is_none());
+    }
+
+    #[test]
+    fn aggregate_activity_rejects_negative_non_finite_and_oversized_values() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join("claude-usage.json"),
+            format!(
+                r#"{{"5h-utilization":"0.25","_source":"oauth","status":"allowed","_today_tokens":-1,"_rate_per_hour":{}}}"#,
+                MAX_AGGREGATE_TOKENS + 1
+            ),
+        )
+        .unwrap();
+
+        let snapshot = UsageCollector::new(temp.path()).sample();
+        let claude = &snapshot.providers[0];
+        assert!(claude.available);
+        assert_eq!(claude.today_tokens, None);
+        assert_eq!(claude.tokens_per_hour, None);
+        assert_eq!(aggregate_tokens(Some(&Value::String("NaN".into()))), None);
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,8 +54,8 @@ portal interaction, so they cannot invalidate a guarded action or wake the
 ambient surface. Usage collection reads only the bounded normalized cache
 contracts already produced by the Omarchy Quickshell AI module. The daemon
 allowlists provider IDs, sources, status values, and safe metadata, clamps
-utilization, rejects oversized files, and never forwards credentials or raw
-provider payloads.
+utilization and aggregate token activity, rejects oversized files, and never
+forwards credentials, prompts, per-model history, or raw provider payloads.
 
 Micro collection uses one fixed read-only `device.status` request on the
 user-private local microd socket. Connected state requires a valid device

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -28,8 +28,11 @@ versions must be rejected.
         "available": true,
         "stale": false,
         "source": "rpc",
-        "status": "ok",
-        "primary": {"label": "WEEKLY", "utilization": 0.74}
+        "status": "allowed",
+        "plan": "pro",
+        "primary": {"label": "WEEKLY", "utilization": 0.74},
+        "today_tokens": 53960987620,
+        "tokens_per_hour": 1778512401
       }
     ]
   },
@@ -56,12 +59,14 @@ Voice state is exactly `idle`, `recording`, `processing`, `error`, or
 dictation marker; snapshots never carry transcripts, tooltips, command output,
 or voice errors from stderr.
 
-`usage` exposes only normalized provider capacity. Utilization is a fraction
-from 0 through 1; reset timestamps, plan, and model are optional bounded
-metadata. It never includes credentials, raw counters, cache file contents, or
-provider response bodies. `micro` is a read-only normalized view of the local
-Codex Micro connection and optional device status. It never exposes the Micro
-socket protocol to QML.
+`usage` exposes only normalized provider capacity and coarse aggregate
+activity. Utilization is a fraction from 0 through 1; reset timestamps, plan,
+model, `today_tokens`, and `tokens_per_hour` are optional bounded metadata.
+The aggregate token fields are provider-wide local activity totals, not
+per-request records. Usage never includes credentials, prompts, per-model
+history, cache file contents, or provider response bodies. `micro` is a
+read-only normalized view of the local Codex Micro connection and optional
+device status. It never exposes the Micro socket protocol to QML.
 
 These additive v1 fields are optional for compatibility with older recorded
 fixtures. Clients default voice to unavailable, review-ready and launch-pending

--- a/quickshell/components/AiUsageDock.qml
+++ b/quickshell/components/AiUsageDock.qml
@@ -7,6 +7,7 @@ Item {
     property var agents: []
     property var sessions: []
     property bool reducedMotion: false
+    property int clockTick: 0
 
     readonly property var providerIds: ["claude", "codex", "opencode"]
 
@@ -33,14 +34,6 @@ Item {
         }
     }
 
-    function primaryWindow(provider) {
-        if (provider.primary !== null && provider.primary !== undefined)
-            return provider.primary
-        if (provider.secondary !== null && provider.secondary !== undefined)
-            return provider.secondary
-        return null
-    }
-
     function percent(window) {
         if (window === null)
             return 0
@@ -51,6 +44,7 @@ Item {
     }
 
     function resetLabel(window) {
+        clockTick
         if (window === null || Number(window.reset_at_ms || 0) <= 0)
             return "NO RESET"
         var remaining = Math.max(
@@ -84,6 +78,191 @@ Item {
         return focused > 0
             ? focused + " FOCUSED"
             : "NO FOCUSED AGENT"
+    }
+
+    function formatTokens(value) {
+        var count = Math.max(0, Number(value || 0))
+        if (count >= 1000000000)
+            return (count / 1000000000).toFixed(
+                count >= 10000000000 ? 1 : 2
+            ) + "B"
+        if (count >= 1000000)
+            return (count / 1000000).toFixed(
+                count >= 100000000 ? 0 : count >= 10000000 ? 1 : 2
+            ) + "M"
+        if (count >= 1000)
+            return (count / 1000).toFixed(count >= 100000 ? 0 : 1) + "K"
+        return Math.floor(count).toString()
+    }
+
+    function activitySummary(provider) {
+        var today = Math.max(0, Number(provider.today_tokens || 0))
+        var rate = Math.max(0, Number(provider.tokens_per_hour || 0))
+        var fields = []
+        if (today > 0)
+            fields.push("TODAY " + formatTokens(today))
+        if (rate > 0)
+            fields.push("RATE " + formatTokens(rate) + "/H")
+        if (fields.length > 0)
+            return fields.join(" · ")
+        if (String(provider.model || "") !== "")
+            return String(provider.model).toUpperCase()
+        return provider.available
+            ? "NO RECENT TOKEN ACTIVITY"
+            : "CAPACITY UNAVAILABLE"
+    }
+
+    function updatedLabel(provider) {
+        clockTick
+        var updated = Number(provider.last_updated_ms || 0)
+        if (updated <= 0)
+            return "UPDATE UNKNOWN"
+        var minutes = Math.max(
+            0,
+            Math.floor((Date.now() - updated) / 60000)
+        )
+        if (minutes < 1)
+            return "UPDATED NOW"
+        if (minutes < 60)
+            return "UPDATED " + minutes + "M AGO"
+        if (minutes < 1440)
+            return "UPDATED " + Math.floor(minutes / 60) + "H AGO"
+        return "UPDATED " + Math.floor(minutes / 1440) + "D AGO"
+    }
+
+    function providerStatus(provider) {
+        if (!provider.available) {
+            if (provider.status === "rejected")
+                return "LIMIT REACHED"
+            if (provider.status === "blocked")
+                return "BLOCKED"
+            if (provider.source === "unknown")
+                return "UNTRUSTED"
+            return "NO DATA"
+        }
+        if (provider.stale)
+            return "STALE"
+        if (provider.status === "allowed_warning")
+            return "WARNING"
+        return "LIVE"
+    }
+
+    function providerDetail(provider) {
+        var plan = String(provider.plan || "").trim()
+        if (plan !== "")
+            return plan.toUpperCase()
+        return provider.kind === "local_budget"
+            ? "LOCAL BUDGET"
+            : "PROVIDER QUOTA"
+    }
+
+    function statusColor(provider, accent) {
+        var state = providerStatus(provider)
+        if (state === "LIVE")
+            return accent
+        if (state === "WARNING" || state === "STALE")
+            return "#e8b56d"
+        if (state === "NO DATA")
+            return "#647787"
+        return "#e08a68"
+    }
+
+    Timer {
+        interval: 60000
+        running: true
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: root.clockTick += 1
+    }
+
+    component UsageLine: Item {
+        property var usageWindow: null
+        property bool providerAvailable: false
+        property color accent: "#6f8aa7"
+        property bool reducedMotion: false
+
+        visible: usageWindow !== null
+        width: parent ? parent.width : 0
+        height: visible ? 18 : 0
+
+        Row {
+            anchors.fill: parent
+            spacing: 8
+
+            Text {
+                width: 72
+                anchors.verticalCenter: parent.verticalCenter
+                text: usageWindow === null
+                    ? ""
+                    : String(usageWindow.label || "USAGE").toUpperCase()
+                textFormat: Text.PlainText
+                color: "#8aa8bd"
+                elide: Text.ElideRight
+                font {
+                    family: "monospace"
+                    pixelSize: 10
+                    weight: Font.DemiBold
+                    letterSpacing: 0.4
+                }
+            }
+
+            Rectangle {
+                width: Math.max(60, parent.width - 72 - 42 - 122 - 24)
+                height: 6
+                anchors.verticalCenter: parent.verticalCenter
+                radius: 3
+                color: "#162333"
+
+                Rectangle {
+                    width: parent.width * (
+                        providerAvailable
+                            ? root.percent(usageWindow) / 100
+                            : 0
+                    )
+                    height: parent.height
+                    radius: parent.radius
+                    color: accent
+
+                    Behavior on width {
+                        NumberAnimation {
+                            duration: reducedMotion ? 0 : 280
+                            easing.type: Easing.OutCubic
+                        }
+                    }
+                }
+            }
+
+            Text {
+                width: 42
+                anchors.verticalCenter: parent.verticalCenter
+                text: providerAvailable
+                    ? root.percent(usageWindow) + "%"
+                    : "—"
+                textFormat: Text.PlainText
+                color: providerAvailable ? accent : "#647787"
+                horizontalAlignment: Text.AlignRight
+                font {
+                    family: "monospace"
+                    pixelSize: 11
+                    weight: Font.Bold
+                }
+            }
+
+            Text {
+                width: 122
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.resetLabel(usageWindow)
+                textFormat: Text.PlainText
+                color: "#617f99"
+                elide: Text.ElideRight
+                horizontalAlignment: Text.AlignRight
+                font {
+                    family: "monospace"
+                    pixelSize: 9
+                    letterSpacing: 0.3
+                }
+            }
+        }
     }
 
     Row {
@@ -148,14 +327,24 @@ Item {
             Rectangle {
                 required property string modelData
                 readonly property var provider: root.provider(modelData)
-                readonly property var window: root.primaryWindow(provider)
-                readonly property int usagePercent: root.percent(window)
+                readonly property var primaryUsage:
+                    provider.primary === undefined ? null : provider.primary
+                readonly property var secondaryUsage:
+                    provider.secondary === undefined ? null : provider.secondary
+                readonly property int primaryPercent: root.percent(primaryUsage)
+                readonly property int secondaryPercent:
+                    root.percent(secondaryUsage)
+                readonly property string statusLabel:
+                    root.providerStatus(provider)
+                readonly property string activityLabel:
+                    root.activitySummary(provider)
                 readonly property color accent: modelData === "claude"
                     ? "#e89562"
                     : modelData === "codex"
                         ? "#63e6ba"
                         : "#a998ff"
 
+                objectName: "usageCard_" + modelData
                 width: (root.width - 286 - 42) / 3
                 height: parent.height
                 radius: 16
@@ -166,18 +355,21 @@ Item {
                     : "#263847"
 
                 Row {
+                    id: providerHeader
+
                     anchors {
                         left: parent.left
                         right: parent.right
                         top: parent.top
                         leftMargin: 18
                         rightMargin: 18
-                        topMargin: 13
+                        topMargin: 10
                     }
-                    height: 25
+                    height: 22
+                    spacing: 9
 
                     Text {
-                        width: parent.width - percentText.width
+                        width: Math.min(132, implicitWidth)
                         text: String(parent.parent.provider.label || "").toUpperCase()
                         textFormat: Text.PlainText
                         color: "#dceff7"
@@ -191,117 +383,107 @@ Item {
                     }
 
                     Text {
-                        id: percentText
-                        text: parent.parent.provider.available
-                            ? parent.parent.usagePercent + "%"
-                            : "—"
+                        width: Math.max(
+                            60,
+                            parent.width - statusText.width - x - 9
+                        )
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: root.providerDetail(parent.parent.provider)
                         textFormat: Text.PlainText
-                        color: parent.parent.provider.available
-                            ? parent.parent.accent
-                            : "#647787"
+                        color: "#5f7f9c"
+                        elide: Text.ElideRight
                         font {
                             family: "monospace"
-                            pixelSize: 18
+                            pixelSize: 9
+                            letterSpacing: 0.4
+                        }
+                    }
+
+                    Text {
+                        id: statusText
+
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: parent.parent.statusLabel
+                        textFormat: Text.PlainText
+                        color: root.statusColor(
+                            parent.parent.provider,
+                            parent.parent.accent
+                        )
+                        font {
+                            family: "monospace"
+                            pixelSize: 9
                             weight: Font.Bold
+                            letterSpacing: 0.6
                         }
                     }
                 }
 
-                Rectangle {
+                Column {
                     anchors {
                         left: parent.left
                         right: parent.right
-                        top: parent.top
+                        top: providerHeader.bottom
                         leftMargin: 18
                         rightMargin: 18
-                        topMargin: 43
+                        topMargin: 4
                     }
-                    height: 7
-                    radius: 4
-                    color: "#162333"
+                    spacing: 3
 
-                    Rectangle {
+                    UsageLine {
                         width: parent.width
-                            * (parent.parent.provider.available
-                                ? parent.parent.usagePercent / 100
-                                : 0)
-                        height: parent.height
-                        radius: parent.radius
-                        color: parent.parent.accent
+                        usageWindow: parent.parent.primaryUsage
+                        providerAvailable: parent.parent.provider.available
+                        accent: parent.parent.accent
+                        reducedMotion: root.reducedMotion
+                    }
 
-                        Behavior on width {
-                            NumberAnimation {
-                                duration: root.reducedMotion ? 0 : 280
-                                easing.type: Easing.OutCubic
-                            }
-                        }
+                    UsageLine {
+                        width: parent.width
+                        usageWindow: parent.parent.secondaryUsage
+                        providerAvailable: parent.parent.provider.available
+                        accent: parent.parent.accent
+                        reducedMotion: root.reducedMotion
                     }
                 }
 
                 Row {
+                    id: providerFooter
+
                     anchors {
                         left: parent.left
                         right: parent.right
                         bottom: parent.bottom
                         leftMargin: 18
                         rightMargin: 18
-                        bottomMargin: 11
+                        bottomMargin: 9
                     }
+                    spacing: 10
 
                     Text {
-                        width: parent.width * 0.52
-                        text: {
-                            var provider = parent.parent.provider
-                            var window = parent.parent.window
-                            if (!provider.available) {
-                                if (provider.status === "blocked"
-                                        || provider.status === "rejected")
-                                    return String(provider.status).toUpperCase()
-                                if (provider.source === "unknown")
-                                    return "UNTRUSTED"
-                                return "NO DATA"
-                            }
-                            if (provider.stale)
-                                return "STALE"
-                            if (provider.kind === "local_budget")
-                                return "LOCAL BUDGET"
-                            return String(
-                                window === null ? "QUOTA" : window.label
-                            ).toUpperCase()
-                        }
+                        width: parent.width * 0.58
+                        text: parent.parent.activityLabel
                         textFormat: Text.PlainText
-                        color: !parent.parent.provider.available
-                                && (parent.parent.provider.status === "blocked"
-                                    || parent.parent.provider.status === "rejected"
-                                    || parent.parent.provider.source === "unknown")
-                            ? "#e08a68"
-                            : parent.parent.provider.stale
-                                ? "#d5a25f"
-                                : "#6888a2"
+                        color: "#7898ae"
                         elide: Text.ElideRight
                         font {
                             family: "monospace"
-                            pixelSize: 10
+                            pixelSize: 9
                             weight: Font.DemiBold
-                            letterSpacing: 0.5
+                            letterSpacing: 0.3
                         }
                     }
 
                     Text {
-                        width: parent.width * 0.48
-                        text: parent.parent.provider.kind === "local_budget"
-                            ? String(
-                                parent.parent.provider.model || "LOCAL ACTIVITY"
-                            ).toUpperCase()
-                            : root.resetLabel(parent.parent.window)
+                        width: parent.width - parent.children[0].width - 10
+                        text: root.updatedLabel(parent.parent.provider)
                         textFormat: Text.PlainText
-                        color: "#6888a2"
+                        color: "#54728c"
                         elide: Text.ElideRight
                         horizontalAlignment: Text.AlignRight
                         font {
                             family: "monospace"
-                            pixelSize: 10
-                            letterSpacing: 0.4
+                            pixelSize: 9
+                            letterSpacing: 0.3
                         }
                     }
                 }

--- a/quickshell/components/PortalView.qml
+++ b/quickshell/components/PortalView.qml
@@ -744,7 +744,7 @@ Item {
             rightMargin: 24
             bottomMargin: 16
         }
-        height: 82
+        height: 106
         usage: root.store.usage
         agents: root.store.agents
         sessions: root.store.sessions

--- a/quickshell/state/PortalStore.qml
+++ b/quickshell/state/PortalStore.qml
@@ -400,6 +400,13 @@ QtObject {
         }
     }
 
+    function normalizeAggregateTokens(value) {
+        if (typeof value !== "number" || !isFinite(value)
+                || value < 0 || value > 1000000000000000)
+            return null
+        return Math.floor(value)
+    }
+
     function normalizeUsage(value) {
         var source = value !== null
                 && value !== undefined
@@ -433,6 +440,12 @@ QtObject {
                 "model": safeString(provider.model, "", 80),
                 "primary": normalizeUsageWindow(provider.primary),
                 "secondary": normalizeUsageWindow(provider.secondary),
+                "today_tokens": normalizeAggregateTokens(
+                    provider.today_tokens
+                ),
+                "tokens_per_hour": normalizeAggregateTokens(
+                    provider.tokens_per_hour
+                ),
                 "last_updated_ms": Math.max(
                     0,
                     finiteNumber(provider.last_updated_ms, 0)

--- a/quickshell/tests/test_fixtures.py
+++ b/quickshell/tests/test_fixtures.py
@@ -143,6 +143,15 @@ class FixtureContractTests(unittest.TestCase):
                             )
                             self.assertIsInstance(provider["available"], bool)
                             self.assertIsInstance(provider["stale"], bool)
+                            for name in ("today_tokens", "tokens_per_hour"):
+                                if name not in provider:
+                                    continue
+                                self.assertIsInstance(provider[name], int)
+                                self.assertGreaterEqual(provider[name], 0)
+                                self.assertLessEqual(
+                                    provider[name],
+                                    1_000_000_000_000_000,
+                                )
                             for name in ("primary", "secondary"):
                                 window = provider.get(name)
                                 if window is None:

--- a/quickshell/tests/tst_ai_usage.qml
+++ b/quickshell/tests/tst_ai_usage.qml
@@ -1,0 +1,127 @@
+import QtQuick
+import QtTest
+import "../components"
+
+TestCase {
+    id: testCase
+
+    name: "AiUsageDock"
+    width: 2560
+    height: 140
+
+    AiUsageDock {
+        id: dock
+
+        width: 2512
+        height: 106
+        reducedMotion: true
+        agents: [
+            {"focused": true},
+            {"focused": false}
+        ]
+        sessions: [{}, {}]
+    }
+
+    function init() {
+        dock.usage = {
+            "providers": [{
+                "id": "claude",
+                "label": "Claude",
+                "kind": "quota",
+                "available": true,
+                "stale": false,
+                "source": "oauth",
+                "status": "allowed_warning",
+                "primary": {
+                    "label": "5h",
+                    "utilization": 0.03,
+                    "reset_at_ms": Date.now() + 7200000
+                },
+                "secondary": {
+                    "label": "Weekly",
+                    "utilization": 0.07,
+                    "reset_at_ms": Date.now() + 604800000
+                },
+                "last_updated_ms": Date.now()
+            }, {
+                "id": "codex",
+                "label": "Codex",
+                "kind": "quota",
+                "available": true,
+                "stale": false,
+                "source": "rpc",
+                "status": "allowed",
+                "plan": "pro",
+                "primary": {
+                    "label": "Weekly",
+                    "utilization": 0.74,
+                    "reset_at_ms": Date.now() + 86400000
+                },
+                "today_tokens": 53960987620,
+                "tokens_per_hour": 1778512401,
+                "last_updated_ms": Date.now()
+            }, {
+                "id": "opencode",
+                "label": "OpenCode",
+                "kind": "local_budget",
+                "available": true,
+                "stale": true,
+                "source": "sqlite",
+                "status": "allowed",
+                "plan": "local messages",
+                "model": "gpt-5.6-sol (openai)",
+                "primary": {
+                    "label": "5h",
+                    "utilization": 0
+                },
+                "secondary": {
+                    "label": "Weekly",
+                    "utilization": 0.0022
+                },
+                "last_updated_ms": Date.now() - 1200000
+            }]
+        }
+    }
+
+    function test_rendersBothWindowsAndAggregateActivity() {
+        var claude = findChild(dock, "usageCard_claude")
+        var codex = findChild(dock, "usageCard_codex")
+        var opencode = findChild(dock, "usageCard_opencode")
+
+        verify(claude !== null)
+        verify(codex !== null)
+        verify(opencode !== null)
+        compare(claude.primaryPercent, 3)
+        compare(claude.secondaryPercent, 7)
+        compare(claude.statusLabel, "WARNING")
+        compare(codex.primaryPercent, 74)
+        compare(codex.secondaryPercent, 0)
+        compare(
+            codex.activityLabel,
+            "TODAY 54.0B · RATE 1.78B/H"
+        )
+        compare(opencode.statusLabel, "STALE")
+        compare(opencode.activityLabel, "GPT-5.6-SOL (OPENAI)")
+    }
+
+    function test_statusAndFormattingStayBoundedAndExplicit() {
+        compare(dock.formatTokens(999), "999")
+        compare(dock.formatTokens(12500), "12.5K")
+        compare(dock.formatTokens(2500000), "2.50M")
+        compare(dock.providerStatus({
+            "available": false,
+            "status": "rejected",
+            "source": "rpc"
+        }), "LIMIT REACHED")
+        compare(dock.providerStatus({
+            "available": false,
+            "status": "allowed",
+            "source": "unknown"
+        }), "UNTRUSTED")
+    }
+
+    function test_fleetSummaryUsesAuthoritativeCollections() {
+        compare(dock.fleetSummary(), "2 AGENTS · 2 SESSIONS")
+        compare(dock.focusedSummary(), "1 FOCUSED")
+    }
+}

--- a/quickshell/tests/tst_store.qml
+++ b/quickshell/tests/tst_store.qml
@@ -218,7 +218,9 @@ TestCase {
                     "label": "Weekly",
                     "utilization": 0.4,
                     "reset_at_ms": 50000
-                }
+                },
+                "today_tokens": -1,
+                "tokens_per_hour": "1000"
             }]
         }
         initial.micro = {
@@ -226,6 +228,8 @@ TestCase {
             "charging": false
         }
         verify(store.ingestEnvelope(initial))
+        compare(store.usage.providers[0].today_tokens, null)
+        compare(store.usage.providers[0].tokens_per_hour, null)
         semanticActivitySpy.clear()
 
         var refresh = snapshot(
@@ -248,6 +252,13 @@ TestCase {
                     "utilization": 1.4,
                     "reset_at_ms": 60000
                 },
+                "secondary": {
+                    "label": "5h",
+                    "utilization": 0.25,
+                    "reset_at_ms": 55000
+                },
+                "today_tokens": 53960987620,
+                "tokens_per_hour": 1778512401,
                 "raw_tokens": 999999
             }, {
                 "id": "hostile-provider",
@@ -272,6 +283,9 @@ TestCase {
         compare(store.usage.providers.length, 1)
         compare(store.usage.providers[0].id, "codex")
         compare(store.usage.providers[0].primary.utilization, 1)
+        compare(store.usage.providers[0].secondary.utilization, 0.25)
+        compare(store.usage.providers[0].today_tokens, 53960987620)
+        compare(store.usage.providers[0].tokens_per_hour, 1778512401)
         compare(store.usage.providers[0].raw_tokens, undefined)
         compare(store.micro.connected, true)
         compare(store.micro.battery, 46)

--- a/schema/portal-v1.schema.json
+++ b/schema/portal-v1.schema.json
@@ -179,6 +179,16 @@
         "model": { "type": "string", "maxLength": 80 },
         "primary": { "$ref": "#/$defs/usageWindow" },
         "secondary": { "$ref": "#/$defs/usageWindow" },
+        "today_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000000000000000
+        },
+        "tokens_per_hour": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000000000000000
+        },
         "last_updated_ms": { "type": "integer", "minimum": 0 }
       }
     },


### PR DESCRIPTION
## What changed

- show both reported AI usage windows, reset timing, plan, freshness, and explicit provider status in the XENEON footer
- add bounded optional `today_tokens` and `tokens_per_hour` fields to the normalized schema-v1 payload
- reject invalid aggregate activity and clear it with other provider data when the source or status is untrusted
- add focused Rust, schema, fixture, store, and rendered QML coverage
- document the expanded privacy boundary and completed physical QA gate

## Why

The source Omarchy bar exposes useful capacity and local-activity context that the XENEON command center previously omitted. This brings the relevant overview data to the dedicated display while keeping prompts, terminal content, credentials, raw provider payloads, and per-model history outside the portal protocol.

## User impact

Claude and OpenCode can show both capacity windows, Codex can show plan and aggregate today/hour activity, and every provider now reports clear live, stale, warning, blocked, untrusted, or unavailable state with freshness timing.

## Validation

- `mise exec -- just check`: 53 core tests, 1 CLI test, strict fmt/clippy, 25 Python tests, 85 Qt tests with `qmllint`, and 25 isolated installer scenarios
- independent Rust/QML review: no substantive findings
- reviewed update installed through the user-owned production installer with exact DP-2 EDID and USB touchscreen identity revalidated
- one `xeneon-edge-agent-portal` surface on DP-2 at 1280x360 logical / 2560x720 native
- both user services active with zero restarts and no recent warnings
- native physical capture visually inspected with no overlap or clipping