### PR TITLE
Prepare the repository for public release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug report
+description: Report a reproducible problem with the agent command center
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not include prompts, terminal contents, credentials, or local hardware identifiers.
+        Report suspected vulnerabilities privately as described in SECURITY.md.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened, and what did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest safe sequence that reproduces the issue.
+      placeholder: |
+        1. Start ...
+        2. Open ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: input
+    id: revision
+    attributes:
+      label: Revision
+      description: Commit SHA, branch, or package version.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Omarchy, Hyprland, Quickshell, Herdr, and relevant hardware versions without unique identifiers.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Checks already performed
+      description: Include safe logs or test results with private data removed.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/spencerbull/xeneon-edge-agents/security/advisories/new
+    about: Privately report a suspected vulnerability

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Propose a focused product or integration improvement
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem should this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the smallest useful behavior and its visible result.
+    validations:
+      required: true
+  - type: textarea
+    id: boundaries
+    attributes:
+      label: Safety and authority boundaries
+      description: Explain any impact on Herdr authority, actions, privacy, display identity, or installation.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you consider?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What changed
+
+Describe the focused change and its user-visible impact.
+
+## Safety and architecture
+
+- [ ] Herdr remains the session and interaction authority.
+- [ ] QML remains presentation-only and sends no arbitrary terminal input.
+- [ ] No prompt, terminal, credential, or raw provider content is exposed.
+- [ ] Display and touchscreen behavior remains fail-closed.
+- [ ] Installation remains user-owned and reversible.
+
+## Verification
+
+List the exact checks, previews, environments, and physical hardware tests run.
+Call out anything intentionally skipped.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thanks for helping improve the XENEON EDGE Agent Command Center.
+
+## Before you start
+
+- Open an issue before proposing a large product or architecture change.
+- Keep Herdr authoritative, `xeneon-agentd` responsible for normalization and
+  actions, and Quickshell presentation-only.
+- Never expose prompts, terminal contents, credentials, or raw provider data.
+- Preserve fail-closed display and touchscreen identity behavior.
+- Keep installation user-owned, reversible, and isolated from packaged
+  Omarchy files.
+
+## Development
+
+Install the pinned tools and run the complete local gate:
+
+```bash
+mise install
+mise exec -- just check
+```
+
+Use `mise run preview` for deterministic UI work. Hardware-facing changes must
+also distinguish fixture validation from physical XENEON testing.
+
+## Pull requests
+
+- Keep each pull request focused and explain its user-visible impact.
+- Add or update focused tests for behavior changes.
+- Include the commands and environments used for verification.
+- Call out skipped physical, accessibility, or runtime checks explicitly.
+- Do not include local commissioning files or hardware identifiers.
+
+By contributing, you agree that your contributions will be licensed under the
+project's [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Spencer Bull
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,28 @@
 # XENEON EDGE Agent Command Center
 
+[![CI](https://github.com/spencerbull/xeneon-edge-agents/actions/workflows/ci.yml/badge.svg)](https://github.com/spencerbull/xeneon-edge-agents/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 A native Omarchy command center for the Corsair XENEON EDGE. It keeps Herdr as
 the session and interaction authority while providing a dedicated 2560x720
 touch surface for agent status, safe triage, provider capacity, and connected
 tool status.
+
+[Watch the XENEON EDGE Agent Command Center in action on X.](https://x.com/SpencerGBull/status/2088048447525966150?s=20)
+
+> [!NOTE]
+> This is an early, hardware-specific project developed and validated on
+> Omarchy with a Corsair XENEON EDGE. There is not yet a general-purpose
+> packaged release; use the source installer and commissioning flow below.
+
+## Highlights
+
+- A glanceable command center and animated Ambient view for Herdr agents.
+- Exact, fail-closed display and touchscreen identity checks.
+- Typed, narrowly scoped agent actions mediated by the Rust daemon.
+- Normalized Claude, Codex, OpenCode, host-health, and connected-tool status.
+- Reversible user-owned installation in XDG locations; no packaged Omarchy
+  files are modified.
 
 Production output matching is fail-closed: the portal creates no surface
 unless the commissioned EDID, model, serial, and touchscreen all match exactly
@@ -25,6 +44,9 @@ or shell commands. Open and zoom are narrow public Herdr API calls. Interrupt
 requires a short-lived capability issued and revalidated by a compatible Herdr
 server; approval is deliberately unavailable until a current prompt can be
 grounded safely.
+
+For the full boundary model, see the [architecture](docs/architecture.md) and
+[protocol](docs/protocol.md) documentation.
 
 ## Develop and preview
 
@@ -165,6 +187,24 @@ The remaining physical checklist covers touch coordinates, focus restoration,
 hotplug, DPMS, suspend/resume, lock-screen privacy, and read-only DDC discovery.
 Brightness control stays disabled until exact read/restore is proven.
 
-See [architecture](docs/architecture.md), [protocol](docs/protocol.md), and
-[commissioning](docs/commissioning.md) for the boundaries and verification
-details. `TODO.md` is the resumable implementation ledger.
+See the [commissioning guide](docs/commissioning.md) for the complete safety
+and verification checklist. `TODO.md` is the resumable implementation ledger.
+
+## Security and privacy
+
+The portal intentionally excludes terminal contents, prompts, credentials, and
+raw provider payloads. Production display matching fails closed when hardware
+identity is absent or ambiguous, and QML cannot execute arbitrary shell input.
+
+Please report security issues through the process in [SECURITY.md](SECURITY.md)
+instead of opening a public issue.
+
+## Contributing
+
+Contributions are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md), keep
+the authority and hardware-safety boundaries intact, and run the repository
+checks before opening a pull request.
+
+## License
+
+This project is available under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported versions
+
+This project is under active development and does not yet publish stable
+release branches. Security fixes are applied to the current `main` branch.
+
+## Reporting a vulnerability
+
+Please use GitHub's private vulnerability reporting for this repository. Do
+not open a public issue for a suspected vulnerability.
+
+Include a concise impact description, affected revision, reproduction steps,
+and any suggested mitigation. Do not include real credentials, prompts,
+terminal contents, or local hardware identity files in the report.
+
+You should receive an initial acknowledgment within seven days. Disclosure and
+fix timing will be coordinated according to severity and available mitigation.

--- a/TODO.md
+++ b/TODO.md
@@ -186,13 +186,12 @@ state; the daemon and portal run only while that exact hardware is present.
 - [x] Card-focus QA verified the full-size target contract, the fixed
       `agent.focus` action against the live preview daemon, and the resulting
       authoritative focused-agent update for `seform-codex`.
-- [x] Physical EDGE display and touch QA identified `DP-2` / serial
-      `066626215698` / EDID SHA-256
-      `311920e1e0982803ea7ec8aee0a1688630095944e025ece9bc741ebb8ac70dc5`,
-      enabled native 2560x720 at 2x scale, mapped only
-      `wch.cn-touchscreen-1` (`0003:27c0:0859`, uniq
-      `9LQ0172005164`), captured a real touch sequence, woke Ambient, tapped
-      `herdr-xeneon`, and observed Herdr report that exact agent focused.
+- [x] Physical EDGE display and touch QA verified the exact commissioned EDID,
+      model, serial, USB identity, and touch device; enabled native 2560x720 at
+      2x scale; captured a real touch sequence; woke Ambient; focused an agent;
+      and observed Herdr report that exact agent focused. Host-specific hardware
+      identifiers remain in the local commissioning file rather than this
+      repository.
 - [x] Production activation verified both user services active with zero
       restarts, a mode-`0600` daemon socket inside a mode-`0700`
       systemd-owned runtime directory, a connected Herdr protocol-17 snapshot

--- a/design-qa.md
+++ b/design-qa.md
@@ -4,18 +4,10 @@ final result: passed
 
 ## Evidence
 
-- Source visual truth:
-  `/home/sbull/Downloads/herdr-xeneon-edge-concept.mp4`
-- Source hash:
-  `a8a4d8bbda6034b301f527463e2938828184a60c6edecc4e323f3f7bbca6ad07`
-- Rectified source transition and tail sheets:
-  `/tmp/xeneon-motion-pass2.cRkBRX/transition-sheet.png` and
-  `/tmp/xeneon-motion-pass2.cRkBRX/tails-sheet.png`
-- Final implementation captures:
-  `/tmp/xeneon-final-motion.1roWWj/control-center-final.png` and
-  `/tmp/xeneon-final-motion.1roWWj/ambient-nested-final.png`
-- Final tail comparison:
-  `/tmp/xeneon-final-motion.1roWWj/tail-comparison-final.png`
+- Source visual truth: a local concept capture that is intentionally not
+  committed to the repository.
+- Rectified transition sheets, implementation captures, and tail comparisons
+  were generated as ephemeral local QA artifacts.
 - Viewport: 1280x360 logical pixels.
 - Source: photographed 1280x720 frame perspective-rectified and normalized to
   1280x360 at density 1.
@@ -24,11 +16,9 @@ final result: passed
 - States compared: operational cards, dashboard-to-radar transition, quiet
   constellation, and energetic orbit.
 
-This is explicitly ephemeral local QA evidence: the source remains in the
-user's Downloads folder and captures remain under `/tmp`. Their paths and
-source hash make this run auditable now, but they are not claimed as durable
-repository artifacts. Regenerate them from the source before a later release
-or review.
+This is explicitly ephemeral local QA evidence, not a durable repository
+artifact. Regenerate it from an authorized source capture before a later
+release or review.
 
 The full view keeps all critical detail legible at the native 1280x360
 comparison size. Focused regions were evaluated through the active card grid

--- a/docs/concept-motion.md
+++ b/docs/concept-motion.md
@@ -2,9 +2,7 @@
 
 ## Source
 
-- File: `/home/sbull/Downloads/herdr-xeneon-edge-concept.mp4`
-- SHA-256:
-  `a8a4d8bbda6034b301f527463e2938828184a60c6edecc4e323f3f7bbca6ad07`
+- File: local concept capture, intentionally not committed.
 - Media: H.264, 1280x720, 24 fps, 240 frames, 10.083 seconds
 - The photographed EDGE content was perspective-rectified to 1280x360 for
   comparison with the portal preview. The synthetic names and telemetry in the

--- a/tests/install_integration.sh
+++ b/tests/install_integration.sh
@@ -12,7 +12,7 @@ production_touch_args=(
   --touch-bustype 0003
   --touch-vendor 27c0
   --touch-product 0859
-  --touch-uniq 9LQ0172005164
+  --touch-uniq TEST-TOUCH-UNIQ-0001
   --touch-phys usb-0000:00:14.0-2.4/input0
 )
 
@@ -88,7 +88,7 @@ make_sysfs_match() {
 make_touchscreen_match() {
   local sys_root=$1
   local event_name=${2:-event90}
-  local uniq=${3:-9LQ0172005164}
+  local uniq=${3:-TEST-TOUCH-UNIQ-0001}
   local phys=${4:-usb-0000:00:14.0-2.4/input0}
   local directory=$sys_root/devices/mock-input/$event_name
   mkdir -p "$directory/device/id" "$directory/device/capabilities" \
@@ -448,7 +448,7 @@ test_production_commissioning_and_exact_check() {
   # USB topology changed from the commissioned 2.4 path to 1.4 after reboot;
   # the device-provided uniq remains the stable touch authority.
   make_touchscreen_match \
-    "$sys_root" event90 9LQ0172005164 usb-0000:00:14.0-1.4/input0
+    "$sys_root" event90 TEST-TOUCH-UNIQ-0001 usb-0000:00:14.0-1.4/input0
   write_hypr_devices "$hypr_devices" wch.cn-touchscreen-1
   write_hypr_monitors "$hypr_monitors"
 
@@ -615,7 +615,7 @@ test_invalid_touch_vendor_does_not_install() {
     --screen-serial CX123456 --screen-model "XENEON EDGE" \
     --touch-device wch.cn-touchscreen-1 \
     --touch-bustype 0003 --touch-vendor zzzz --touch-product 0859 \
-    --touch-uniq 9LQ0172005164 >"$log" 2>&1; then
+    --touch-uniq TEST-TOUCH-UNIQ-0001 >"$log" 2>&1; then
     fail "non-hexadecimal touch vendor unexpectedly passed"
   fi
   assert_contains "$log" \
@@ -1348,7 +1348,7 @@ test_hotplug_reconciler_tracks_identity_across_connector_drift() {
 
   make_sysfs_match "$sys_root" card0 DP-2 "$fixture"
   make_touchscreen_match \
-    "$sys_root" event90 9LQ0172005164 usb-0000:00:14.0-1.4/input0
+    "$sys_root" event90 TEST-TOUCH-UNIQ-0001 usb-0000:00:14.0-1.4/input0
   write_hypr_devices "$devices" wch.cn-touchscreen-1
   cat >"$monitors" <<'EOF'
 [{"id":2,"name":"DP-2","model":"XENEON EDGE","serial":"CX123456","width":2560,"height":720}]


### PR DESCRIPTION
## What changed

- add the MIT license, contribution guide, and security policy
- add structured bug/feature issue forms and a pull request template
- improve the README with project status, highlights, CI/license badges, safety guidance, and the public X demo
- remove host-specific hardware identifiers and ephemeral local paths from the current documentation
- replace the real touch `uniq` used by installer tests with an explicitly synthetic fixture

## Why

The repository is being prepared for public visibility. The default branch should clearly explain the project, its safety boundaries, how to develop and commission it, how to contribute, and how to report security issues without publishing host-specific identifiers.

## Verification

- `mise exec -- just check`
  - 60 Rust core tests and 1 CLI test passed
  - strict Clippy and formatting passed
  - 26 Python QML contracts and 85 Qt tests passed
  - 31 installer/integration scenarios passed
  - ShellCheck and `git diff --check` passed
- parsed all issue-form YAML with Ruby `YAML.safe_load_file`
- verified README relative-link targets
- scanned the candidate tree for credential patterns and known host-specific identifiers