### PR TITLE
Add theme-aware dense agent command center

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cc"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,10 +170,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "futures-core"
@@ -252,6 +286,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +344,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +366,18 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -356,6 +419,19 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rusqlite"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustix"
@@ -442,6 +518,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -543,6 +625,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -704,6 +816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,10 +904,12 @@ name = "xeneon-agent-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "toml",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,10 @@ anyhow = "1.0.100"
 clap = { version = "4.5.54", features = ["derive", "env"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+rusqlite = { version = "0.40.2", default-features = false, features = ["bundled", "hooks"] }
 tempfile = "3.24.0"
 thiserror = "2.0.17"
+time = { version = "0.3.55", features = ["parsing"] }
 tokio = { version = "1.49.0", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 toml = "0.9.8"
 tracing = "0.1.44"

--- a/README.md
+++ b/README.md
@@ -79,16 +79,34 @@ scripts/preview --live --ambient-after 6
 ```
 
 The control center shows safe Herdr identity, state duration, repository and
-worktree context, plus the Omarchy AI module's normalized Claude, Codex, and
-OpenCode capacity. The AI footer shows both reported usage windows, resets,
-plan/freshness state, and bounded today/hour token activity when available.
+worktree context, plus normalized Claude, Codex, and OpenCode capacity. The
+daemon consumes Omarchy's schema-v1 Claude/Codex agent records, keeps legacy
+cache compatibility, and derives OpenCode's local soft-budget windows from its
+newly processed token counters (input, output, reasoning, and cache-write;
+reused cache-read context is excluded) in the
+read-only SQLite message ledger. The AI footer shows both reported usage
+windows, resets, plan/freshness state, and bounded today/hour token activity
+when available.
 Header controls use typed daemon actions to focus or launch the fixed ChatGPT
 Desktop and Claude Desktop entries. The Micro control opens a read-only virtual
 projection of the connected device and current agent slots.
+The Order control reads and writes Herdr's own grouped/priority setting, so the
+Herdr Agents panel and EDGE cards stay synchronized instead of keeping separate
+preferences.
 The upper-right Motion and Screen controls are shared by the command-center
 and Ambient views. Motion snaps the ambient constellation to fixed positions
 and removes perimeter/trail animation; Screen applies a reversible near-black
 portal veil. These presentation settings persist across portal restarts.
+
+Portal chrome follows Omarchy's active runtime theme. The named Quickshell
+configuration reads the allowlisted colors in
+`$XDG_STATE_HOME/omarchy/current/theme/colors.toml` and watches the stable
+`theme.name` file, so `omarchy theme set` updates backgrounds, surfaces, text,
+borders, and semantic accents without restarting the portal. Missing or
+invalid colors fall back safely. State meaning stays stable while its hue comes
+from the active theme: working uses blue, blocked uses yellow, review-ready
+uses green, and errors use red. Light Omarchy themes are translated into
+contrast-checked dark EDGE chrome while retaining their palette hues.
 
 The live preview exposes the real narrow agent-focus, desktop-app, and voice
 actions. Voice

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ invalid colors fall back safely. State meaning stays stable while its hue comes
 from the active theme: working uses blue, blocked uses yellow, review-ready
 uses green, and errors use red. Light Omarchy themes are translated into
 contrast-checked dark EDGE chrome while retaining their palette hues.
+The top-right Palette control shows the live Omarchy swatches and lets you map
+those allowlisted theme roles onto XENEON's Ready, Success, Working, Needs
+Help, Review Ready, Error, Unknown, Recording, and Processing meanings. Mappings
+apply immediately to the command center and Ambient view, persist beside the
+Motion and Screen preferences, and can be reset to the reviewed defaults.
+Arbitrary colors are not accepted; chrome and text contrast remain automatic.
 
 The live preview exposes the real narrow agent-focus, desktop-app, and voice
 actions. Voice

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,14 @@ Fable 5 over a persistent ACP session. Any verified findings are fixed only on
 `claude-fable-review`, revalidated through the required software gates, and
 returned to the same reviewer until no substantive findings remained.
 
+The completed source theme-sync checkpoint makes portal chrome follow Omarchy's current
+runtime palette without copying a named theme. The project-owned QML reader
+watches Omarchy's stable theme-name beacon, reloads the atomically replaced
+`colors.toml`, validates an allowlisted palette, and retains the fixed agent
+state meanings while mapping their hues to the active theme's blue, yellow,
+green, and red roles.
+Installation and a physical theme switch remain a separate live gate.
+
 The active hotplug checkpoint replaces connector-pinned autostart with an
 event-driven lifecycle. The commissioned EDID, serial/model, and USB touch
 identity remain authoritative while the current connector becomes runtime
@@ -51,8 +59,9 @@ state; the daemon and portal run only while that exact hardware is present.
       user-owned configuration.
 - [x] Automated checks and completed independent reviews pass.
 - [x] Portal cards use the same public agent names as Herdr's Agents section.
-- [x] Agent colors, voice states, and ambient perimeter behavior match the
-      reviewed Codex Micro state contract with reduced-motion support.
+- [x] Agent colors, voice states, and ambient perimeter behavior retain the
+      reviewed Codex Micro meanings, use active Omarchy hue roles, and support
+      reduced motion.
 - [x] Ambient transition and orbital motion match the concept timing and
       hierarchy without changing portal action authority.
 - [x] Revised live laptop preview is visually compared with rectified concept
@@ -97,6 +106,7 @@ state; the daemon and portal run only while that exact hardware is present.
 | --- | --- | --- | --- |
 | Foundation and Rust adapter | `main` | Rust workspace, schemas, fixtures | Complete through `c32b5cd` |
 | Herdr safe actions | `agent/xeneon-safe-actions` in the Herdr repository | Public Herdr API, PTY guard, tests, next docs | Installed from reviewed v0.8.0 head `fd53378d`; not pushed |
+| Shared agent ordering | `xeneon-order-mode-sync` in `herdr-worktrees/xeneon-order-mode-sync` plus `omarchy-theme-sync` here | Herdr `agent.order.get/set`, adapter snapshot/action, QML toggle, ordering and motion tests | XENEON follow-up installed and independently reviewed; Herdr live handoff is blocked by the running server's 64-pane limit (67 panes present), so ordering remains unavailable |
 | Quickshell portal | `main` | `quickshell/`, QML tests | Complete through `34e6037` |
 | Live naming, voice, and ambient ring UX | `agent/portal-voice-ring` in `portal-voice-ring` worktree | normalized public protocol fields, `quickshell/`, fixtures, UX docs/tests | Live on the physical EDGE; remaining power/privacy checks are open |
 | Concept motion parity | `agent/portal-voice-ring` in `portal-voice-ring` worktree | ambient presentation, preview timing, visual QA | Live on the physical EDGE; remaining power/privacy checks are open |
@@ -104,6 +114,7 @@ state; the daemon and portal run only while that exact hardware is present.
 | AI usage detail expansion | `main` | bounded usage protocol, AI dock, tests/docs | Complete, installed, and physically verified |
 | Full Claude Fable 5 review | `claude-fable-review` | complete tracked repository; preserve untracked `packaging/` artifacts | Complete: all 14 findings fixed and ACP re-review clean |
 | Desktop launcher | `desktop-launcher` | managed XDG desktop entry, helper, icon, installer lifecycle, tests | Complete, installed, and launched through Omarchy |
+| Omarchy runtime theme sync | `omarchy-theme-sync` | project-owned QML palette reader, semantic chrome and state tokens, theme reload/fallback tests | Theme sync and semantic state roles installed, reviewed, and physically verified |
 | Herdr v0.8 compatibility | `herdr-v0.8-compat` in `herdr-v0.8-compat` worktree | Herdr protocol gate, adapter fixture, protocol docs | Installed from `6edfcd3`; live handoff, protocol 19 connection, services, and production checker passed |
 | Hotplug lifecycle | `hotplug-lifecycle` in `hotplug-lifecycle` worktree | lifecycle reconciler, user units, Hyprland event hook, runtime connector override, installer/tests | Installed and independently reviewed; exact `DP-2` unplug stopped both services and replug restored the stack and touch mapping; burst and mid-settle races are covered by regression tests |
 | Global display controls | `agent/portal-voice-ring` in `portal-voice-ring` worktree | persistent presentation settings, reduced-motion composition, dim veil | Live on the physical EDGE; default full-motion/normal-screen state restored |
@@ -248,13 +259,123 @@ state; the daemon and portal run only while that exact hardware is present.
       Apps menu, launched it through that menu, rendered its success
       notification, kept already-running service PIDs stable, and separately
       restored a deliberately stopped portal through `gtk-launch` on DP-1.
-- [x] Herdr v0.8 compatibility gate: protocol-19 adapter fixture and full
-      repository software checks pass against the rebased Herdr API contract.
+- [x] Historical Herdr v0.8 compatibility gate: protocol-19 adapter fixture and
+      full repository software checks passed against that earlier rebased API
+      contract; the current protocol-20 checkpoint below supersedes it.
+- [x] Omarchy theme-sync base source gate: strict palette parsing and fallback
+      tests, repeated atomic theme-directory replacement in a source preview,
+      full QML lint/tests, 31 installer scenarios, Rust and ShellCheck gates,
+      plus independent review with no P0-P2 findings.
+- [x] Install the reviewed theme-sync base and verify its active Omarchy
+      palette renders on the physical EDGE.
+- [x] Finish review, install the semantic state-role follow-up, and verify the
+      theme-derived blue/yellow/green/red meanings on the physical EDGE.
+- [x] Restore Claude, Codex, and OpenCode capacity after Omarchy replaced the
+      legacy model-usage caches with schema-v1 agent records. Done requires
+      legacy compatibility, fail-closed normalized parsing, a read-only local
+      OpenCode fallback, Rust/full-repository gates, independent review, and
+      live EDGE verification with all three cards populated.
 - [ ] Physical hardware gate (hotplug, DPMS, suspend/resume, privacy,
       guarded-hold behavior, and DDC restore remain).
+- [ ] Fit 14 agents per fixed 2560x720 command-center page, keep the full
+      Claude/Codex quota-window labels visible, and show each card's Herdr
+      space name for dense grouping. Show up to the same 14 agents on a
+      bounded independent-lane ambient animation instead of the previous
+      six-node cap; full-motion lanes may intentionally cross and overlap,
+      while reduced motion stays static and evenly spaced.
+      Done requires QML gates,
+      independent review, a reviewed reinstall, a temporary 20-agent Herdr
+      population proving 14+6 pagination, physical EDGE screenshots, and
+      cleanup of only the disposable test tabs.
+- [ ] Synchronize the EDGE grouped/priority control with Herdr's authoritative
+      persisted ordering and restore the exact original independent ambient
+      motion through six agents while extending the same independent-lane
+      character through fourteen bounded nodes. Done requires Herdr and XENEON
+      tests, independent reviews, a
+      reviewed Herdr live handoff, physical toggle verification from both UIs,
+      and physical ambient visual QA.
 
 ## Current local state
 
+- Active goal (2026-08-13): replace the stock Omarchy Herdr protocol-20
+  installation with the reviewed custom fork rebased onto exact packaged commit
+  `0766aa57ee0ceb4410ae064e94c0f0557853eee7`, update XENEON for protocol 20,
+  and restore guarded actions plus grouped/priority synchronization. Done
+  requires focused and broad gates in both repositories, independent review,
+  a state-preserving Herdr live handoff, reviewed XENEON reinstall, live API
+  and physical EDGE verification, and cleanup of only loop-created resources.
+  Visible implementation worker `herdr_p20_impl` (Codex) runs in Herdr pane
+  `wW:pF`, tab `wW:t1`, workspace `wW`, cwd/worktree
+  `/home/sbull/src/github.com/spencerbull/herdr-worktrees/xeneon-order-mode-sync`,
+  branch `xeneon-order-mode-sync`; the orchestrator owns verification and pane
+  cleanup. A second visible Codex worker, `herdr_handoff_cap`, owns only the
+  bounded 79-pane live-handoff prerequisite in pane `wW:pG`, tab `wW:t1`,
+  workspace `wW`, cwd/worktree
+  `/home/sbull/src/github.com/spencerbull/herdr-worktrees/xeneon-handoff-capacity`,
+  branch `xeneon-handoff-capacity`; the orchestrator owns integration, review,
+  and cleanup. The XENEON independent pre-install review found three P2
+  acceptance/handoff gaps (explicit protocol-19 rejection, rendered degraded
+  reason coverage, and stale ledger evidence); all were remediated and the
+  final re-review is GO with no P0-P2 findings. XENEON is installed and live;
+  the Herdr branch is pushed and its reviewed package is built, but privileged
+  package installation remains at the visible sudo prompt. No PR is planned
+  against upstream under its external-contributor policy.
+
+- The 14-agent layout source and cleanup gates are complete: QML tests prove
+  14+6 pagination, a temporary 20-agent Herdr population physically verified
+  the first 14-card page plus the fourteen-node ambient view, and all 11
+  disposable tabs were closed. A physical second-page screenshot remains open.
+- The grouped/priority follow-up is source-complete in isolated Herdr branch
+  `xeneon-order-mode-sync`, now rebased onto exact Omarchy protocol-20 commit
+  `0766aa57` with a reviewed 128-descriptor handoff prerequisite for the current
+  79-pane session, plus the current XENEON branch. The integrated Herdr gate
+  passes 3,465 Rust tests, strict Clippy including Windows, UI/integration/
+  marketplace suites, and 98 maintenance/schema/docs/vendor tests. The current
+  XENEON gate passes 78 Rust core tests, 104 Qt tests, 27 Python contracts, and
+  all 31 installer scenarios. The final XENEON re-review is GO; the reviewed
+  release binaries and full Quickshell tree are installed. Live validation
+  reports one connected protocol-20 session with 18 agents, zero service
+  restarts, 0-1% sampled daemon CPU after replacing the stale release artifact,
+  clean `scripts/check.sh`/`hyprctl configerrors`, and a visually inspected
+  2560x720 EDGE frame with 14 cards on page one. The prior reviewed Herdr
+  handoff made no state change because the
+  then-running server had 67 panes and v0.8.0 refused more than 64. The retained
+  backup remains available. The custom Herdr branch is pushed to the fork at
+  `51af53be`; its epoch-1 Arch package is built and reviewed, but awaits the
+  user's sudo password. The running stock server remains intentionally intact,
+  so ordering is unavailable in the portal until a future controlled cold
+  restart activates the installed fork; the stock 64-descriptor exporter cannot
+  preserve the current 79-plus-pane session through a live handoff.
+  The previously reviewed XENEON side is installed: physical EDGE frames
+  with 14 agents confirm the bounded independent lanes change relative order,
+  cross, and overlap instead of moving as a rigid revolving formation. Both
+  application services remained active with zero restarts during that check.
+
+- `omarchy-theme-sync` is based on current `origin/main` and contains the
+  uncommitted theme integration plus a semantic state-role follow-up. The
+  theme/QML and usage-remediation source is installed and physically verified
+  but is not yet committed or pushed.
+- Production reinstall reverified the exact DP-2 EDID, XENEON serial/model,
+  and USB touchscreen identity before activation, then correctly followed the
+  same hardware after connector drift to live `DP-1`. The deployed Quickshell
+  tree matches current source. Both services are active with zero restarts,
+  the lifecycle reports `state=running`, and one inspected portal layer
+  renders only on the XENEON using the active `rebel-rebel` palette.
+- The source preview followed the real `rebel-rebel` palette and an isolated
+  atomic purple-to-cyan theme replacement without restart. A final current
+  fixture preview was visually inspected and closed cleanly.
+- Theme validation passes 27 Python QML contracts, 93 Qt tests, all 31
+      installer scenarios, 60 Rust core tests, the CLI fixture test, Clippy,
+      rustfmt, ShellCheck, and `git diff --check`.
+- The August 11 Omarchy usage migration regression is fixed in the installed
+  daemon. Claude and Codex consume fresh fail-closed schema-v1 Omarchy records;
+  OpenCode derives its documented local soft-budget signal from bounded scalar
+  counters in the read-only message ledger. Two independent final reviews
+  reported no P0-P2 findings. Full gates pass: 68 Rust core tests plus the CLI
+  fixture, strict Clippy/rustfmt, 27 Python and 93 Qt QML tests, 30 installer
+  scenarios, ShellCheck, and `git diff --check`. The live snapshot reports all
+  three providers available and fresh, and the physical DP-1 EDGE screenshot
+  shows populated Claude 9%/4%, Codex 58%, and OpenCode 1%/0% cards.
 - PR #2 is squash-merged on `main` at `7eb773c`, including the reviewed
   physical commissioning, naming/voice/ring UX, card accents, and persistent
   display controls.
@@ -277,8 +398,8 @@ state; the daemon and portal run only while that exact hardware is present.
   reset timing, plan/freshness and explicit status, plus bounded aggregate
   today/hour activity when available; no prompts, per-model history,
   credentials, or raw provider payloads cross the protocol.
-- The uncommitted `claude-fable-review` remediation isolates Herdr refreshes
-  from the privacy-sensitive collector loop, fails closed on non-17 Herdr
+- The uncommitted remediation isolates Herdr refreshes
+  from the privacy-sensitive collector loop, fails closed on non-20 Herdr
   protocols and untrusted usage text, repairs QML recovery behavior, removes
   the retired HealthStrip, and adds ShellCheck plus an Arch/Quickshell CI gate.
 - Portal preferences persist at

--- a/TODO.md
+++ b/TODO.md
@@ -270,6 +270,12 @@ state; the daemon and portal run only while that exact hardware is present.
       palette renders on the physical EDGE.
 - [x] Finish review, install the semantic state-role follow-up, and verify the
       theme-derived blue/yellow/green/red meanings on the physical EDGE.
+- [ ] Add a top-right persisted Palette pane that shows the current Omarchy
+      swatches and maps allowlisted roles onto Ready, Success, Working, Needs
+      Help, Review Ready, Error, Unknown, Recording, and Processing. Done requires
+      focused and full QML gates, hosted CI, independent review, a reviewed
+      reinstall, and physical verification in command-center and Ambient
+      views across at least two Omarchy themes.
 - [x] Restore Claude, Codex, and OpenCode capacity after Omarchy replaced the
       legacy model-usage caches with schema-v1 agent records. Done requires
       legacy compatibility, fail-closed normalized parsing, a read-only local
@@ -352,9 +358,24 @@ state; the daemon and portal run only while that exact hardware is present.
   application services remained active with zero restarts during that check.
 
 - `omarchy-theme-sync` is based on current `origin/main` and contains the
-  uncommitted theme integration plus a semantic state-role follow-up. The
-  theme/QML and usage-remediation source is installed and physically verified
-  but is not yet committed or pushed.
+  pushed theme integration, semantic state-role follow-up, dense layout,
+  protocol-20 adapter, and usage remediation in draft PR #7. A persisted
+  allowlisted Palette pane and the hosted font-metric fix are now being added
+  before merge; neither incremental change is installed or pushed yet.
+  Independent read-only reviewer `xeneon_palette_review` (Claude) completed
+  the review/fix/re-review loop with no remaining P0-P2 findings; its Herdr
+  pane `wW:pN` was closed after graceful agent exit. Physical pane/two-theme
+  QA, push, and hosted CI remain. Final local
+  revalidation passes 78 Rust core tests, the CLI test, strict Clippy/rustfmt,
+  ShellCheck, 27 Python and 112 Qt QML tests, all 31 installer scenarios, and
+  `git diff --check`. The reviewed tree is installed after exact output/touch
+  preflight; both services are active with zero restarts, installed Quickshell
+  files match source, and Hyprland reports no config errors. A compositor-native
+  2560x720 Tokyo Night capture confirms the new Palette button and 14-card
+  command-center layout. The installed `cua-driver` 0.7.1 cannot capture this
+  multi-monitor Wayland layer surface (`GetImage` Match failure), so opening
+  the pane and two-theme physical QA remain human/live gates; no CUA action was
+  attempted after capture failed.
 - Production reinstall reverified the exact DP-2 EDID, XENEON serial/model,
   and USB touchscreen identity before activation, then correctly followed the
   same hardware after connector drift to live `DP-1`. The deployed Quickshell

--- a/crates/xeneon-agent-core/Cargo.toml
+++ b/crates/xeneon-agent-core/Cargo.toml
@@ -7,9 +7,11 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
+rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+time.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true

--- a/crates/xeneon-agent-core/src/health.rs
+++ b/crates/xeneon-agent-core/src/health.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashSet,
     fs,
     path::{Path, PathBuf},
     time::Instant,
@@ -54,11 +53,10 @@ impl HealthCollector {
                 || Metric::unavailable("°C"),
                 |value| Metric::available(value, "°C"),
             ),
-            gpu: first_number_matching(&self.sys_root.join("class/drm"), "gpu_busy_percent", 1.0)
-                .map_or_else(
-                    || Metric::unavailable("%"),
-                    |value| Metric::available(value, "%"),
-                ),
+            gpu: gpu_busy_percent(&self.sys_root).map_or_else(
+                || Metric::unavailable("%"),
+                |value| Metric::available(value, "%"),
+            ),
             gpu_temperature: gpu_temperature(&self.sys_root).map_or_else(
                 || Metric::unavailable("°C"),
                 |value| Metric::available(value, "°C"),
@@ -198,40 +196,39 @@ fn first_temperature(root: &Path) -> Option<f64> {
 }
 
 fn gpu_temperature(sys_root: &Path) -> Option<f64> {
-    first_number_matching(&sys_root.join("class/drm"), "temp1_input", 1_000.0)
+    drm_cards(&sys_root.join("class/drm")).find_map(|card| {
+        let device = card.join("device");
+        sorted_dirs_following_symlinks(&device.join("hwmon"))
+            .into_iter()
+            .find_map(|hwmon| read_number(&hwmon.join("temp1_input"), 1_000.0))
+    })
 }
 
-fn first_number_matching(root: &Path, file_name: &str, divisor: f64) -> Option<f64> {
-    let mut stack = vec![root.to_path_buf()];
-    let mut seen = HashSet::new();
-    let mut visited = 0;
-    while let Some(path) = stack.pop() {
-        if visited >= 512 {
-            break;
-        }
-        let Ok(canonical) = fs::canonicalize(&path) else {
-            continue;
-        };
-        if !seen.insert(canonical) {
-            continue;
-        }
-        visited += 1;
-        let Ok(entries) = fs::read_dir(&path) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let child = entry.path();
-            if child.file_name().is_some_and(|name| name == file_name)
-                && let Some(value) = read_number(&child, divisor)
-            {
-                return Some(value);
-            }
-            if fs::metadata(&child).is_ok_and(|metadata| metadata.is_dir()) {
-                stack.push(child);
-            }
-        }
-    }
-    None
+fn gpu_busy_percent(sys_root: &Path) -> Option<f64> {
+    drm_cards(&sys_root.join("class/drm")).find_map(|card| {
+        read_number(&card.join("device/gpu_busy_percent"), 1.0)
+            .or_else(|| read_number(&card.join("gpu_busy_percent"), 1.0))
+    })
+}
+
+fn drm_cards(root: &Path) -> impl Iterator<Item = PathBuf> {
+    let mut cards: Vec<_> = fs::read_dir(root)
+        .into_iter()
+        .flat_map(|entries| entries.flatten())
+        .filter(|entry| {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                return false;
+            };
+            let Some(index) = name.strip_prefix("card") else {
+                return false;
+            };
+            !index.is_empty() && index.bytes().all(|byte| byte.is_ascii_digit())
+        })
+        .map(|entry| entry.path())
+        .collect();
+    cards.sort();
+    cards.into_iter()
 }
 
 fn read_number(path: &Path, divisor: f64) -> Option<f64> {
@@ -249,6 +246,17 @@ fn sorted_dirs(root: &Path) -> Vec<PathBuf> {
         .flat_map(|entries| entries.flatten())
         .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
         .map(|entry| entry.path())
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn sorted_dirs_following_symlinks(root: &Path) -> Vec<PathBuf> {
+    let mut paths: Vec<_> = fs::read_dir(root)
+        .into_iter()
+        .flat_map(|entries| entries.flatten())
+        .map(|entry| entry.path())
+        .filter(|path| fs::metadata(path).is_ok_and(|kind| kind.is_dir()))
         .collect();
     paths.sort();
     paths
@@ -330,17 +338,28 @@ mod tests {
     }
 
     #[test]
-    fn follows_drm_class_symlink_without_looping() {
+    fn reads_bounded_drm_card_metrics_without_recursive_device_walk() {
         let root = tempfile::tempdir().unwrap();
         let device = root.path().join("devices/gpu");
         write(&device.join("gpu_busy_percent"), "37\n");
+        write(&device.join("hwmon/hwmon0/temp1_input"), "51000\n");
+        write(&device.join("unrelated/nested/gpu_busy_percent"), "99\n");
         let drm = root.path().join("sys/class/drm");
-        fs::create_dir_all(&drm).unwrap();
-        symlink(&device, drm.join("card1")).unwrap();
+        fs::create_dir_all(drm.join("card1")).unwrap();
+        symlink(&device, drm.join("card1/device")).unwrap();
 
-        assert_eq!(
-            first_number_matching(&drm, "gpu_busy_percent", 1.0),
-            Some(37.0)
-        );
+        assert_eq!(gpu_busy_percent(&root.path().join("sys")), Some(37.0));
+        assert_eq!(gpu_temperature(&root.path().join("sys")), Some(51.0));
+    }
+
+    #[test]
+    fn ignores_connector_and_unbounded_drm_subtrees() {
+        let root = tempfile::tempdir().unwrap();
+        let drm = root.path().join("sys/class/drm");
+        write(&drm.join("card0-DP-1/device/gpu_busy_percent"), "88\n");
+        write(&drm.join("renderD128/nested/gpu_busy_percent"), "77\n");
+
+        assert_eq!(gpu_busy_percent(&root.path().join("sys")), None);
+        assert_eq!(gpu_temperature(&root.path().join("sys")), None);
     }
 }

--- a/crates/xeneon-agent-core/src/herdr.rs
+++ b/crates/xeneon-agent-core/src/herdr.rs
@@ -18,11 +18,12 @@ use tokio::{
 use uuid::Uuid;
 
 use crate::model::{
-    ActionCapability, ActionKind, AgentActions, AgentStatus, AgentView, SessionState, SessionView,
+    ActionCapability, ActionKind, AgentActions, AgentOrderMode, AgentStatus, AgentView,
+    SessionState, SessionView,
 };
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
-const SUPPORTED_HERDR_PROTOCOL: u32 = 19;
+const SUPPORTED_HERDR_PROTOCOL: u32 = 20;
 
 #[derive(Debug, Clone)]
 pub struct HerdrClient {
@@ -52,6 +53,7 @@ pub struct SessionObservation {
     pub agents: Vec<AgentView>,
     pub targets: HashMap<String, AgentTarget>,
     pub pane_ids: Vec<String>,
+    pub agent_order: Option<AgentOrderMode>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -200,6 +202,7 @@ impl HerdrClient {
                 agents: Vec::new(),
                 targets: HashMap::new(),
                 pane_ids: Vec::new(),
+                agent_order: None,
             });
         }
         let response: SnapshotResponse = request(
@@ -207,6 +210,13 @@ impl HerdrClient {
             json!({"id": request_id(), "method": "session.snapshot", "params": {}}),
         )
         .await?;
+        let agent_order = match self.get_agent_order(descriptor).await {
+            Ok(mode) => Some(mode),
+            Err(error) => {
+                tracing::debug!(session = %descriptor.name, %error, "Herdr agent ordering API unavailable");
+                None
+            }
+        };
 
         let workspaces: HashMap<_, _> = response
             .result
@@ -275,6 +285,7 @@ impl HerdrClient {
                 session: descriptor.name.clone(),
                 focused: raw.focused,
                 observed_for_seconds: 0,
+                state_change_seq: raw.state_change_seq,
                 source_order: source_offset + index,
                 actions: AgentActions {
                     open: true,
@@ -296,7 +307,39 @@ impl HerdrClient {
             agents,
             targets,
             pane_ids,
+            agent_order,
         })
+    }
+
+    pub async fn set_agent_order(
+        &self,
+        descriptor: &SessionDescriptor,
+        mode: AgentOrderMode,
+    ) -> Result<()> {
+        let order = match mode {
+            AgentOrderMode::Grouped => "grouped",
+            AgentOrderMode::Priority => "priority",
+        };
+        let response: Value = request(
+            &descriptor.socket_path,
+            json!({
+                "id": request_id(),
+                "method": "agent.order.set",
+                "params": {"order": order}
+            }),
+        )
+        .await?;
+        if let Some(error) = response.get("error") {
+            bail!("Herdr agent ordering failed: {error}");
+        }
+        if response["result"]["type"] != "agent_order" || response["result"]["order"] != order {
+            bail!("unexpected Herdr agent ordering response");
+        }
+        Ok(())
+    }
+
+    pub async fn get_agent_order(&self, descriptor: &SessionDescriptor) -> Result<AgentOrderMode> {
+        read_agent_order(&descriptor.socket_path).await
     }
 
     pub async fn perform(
@@ -321,6 +364,9 @@ impl HerdrClient {
             }
             ActionKind::VoiceStart | ActionKind::VoiceStop | ActionKind::VoiceCancel => {
                 bail!("voice action is not a Herdr action")
+            }
+            ActionKind::OrderGrouped | ActionKind::OrderPriority => {
+                bail!("agent ordering is not an agent-target action")
             }
         };
         let response: Value = request(&target.socket_path, payload).await?;
@@ -349,6 +395,26 @@ impl HerdrClient {
         });
         (handle, ready_rx)
     }
+}
+
+async fn read_agent_order(socket_path: &Path) -> Result<AgentOrderMode> {
+    let response: Value = request(
+        socket_path,
+        json!({"id": request_id(), "method": "agent.order.get", "params": {}}),
+    )
+    .await?;
+    if let Some(error) = response.get("error") {
+        bail!("Herdr agent ordering failed: {error}");
+    }
+    if response["result"]["type"] != "agent_order" {
+        bail!("unexpected Herdr agent ordering response");
+    }
+    let mode = match response["result"]["order"].as_str() {
+        Some("grouped") => AgentOrderMode::Grouped,
+        Some("priority") => AgentOrderMode::Priority,
+        _ => bail!("unexpected Herdr agent ordering response"),
+    };
+    Ok(mode)
 }
 
 fn display_name(raw: &HerdrAgent, tabs: &HashMap<String, String>, agent_name: &str) -> String {
@@ -669,8 +735,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn unsupported_protocol_never_requests_or_surfaces_session_data() {
+    async fn observe_unsupported_protocol(protocol: u32) -> SessionObservation {
         let temp = tempdir().unwrap();
         let socket = temp.path().join("herdr.sock");
         let listener = UnixListener::bind(&socket).unwrap();
@@ -681,15 +746,13 @@ mod tests {
             let request: Value =
                 serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
             assert_eq!(request["method"], "ping");
-            write
-                .write_all(
-                    b"{\"id\":\"ping\",\"result\":{\"version\":\"future\",\"protocol\":999}}\n",
-                )
-                .await
-                .unwrap();
+            let response = format!(
+                "{{\"id\":\"ping\",\"result\":{{\"version\":\"unsupported\",\"protocol\":{protocol}}}}}\n"
+            );
+            write.write_all(response.as_bytes()).await.unwrap();
         });
         let descriptor = SessionDescriptor {
-            name: "future".into(),
+            name: "unsupported".into(),
             running: true,
             socket_path: socket,
         };
@@ -698,17 +761,25 @@ mod tests {
             .observe_session(&descriptor, "epoch", 0, 1234)
             .await
             .unwrap();
-
-        assert_eq!(observation.session.state, SessionState::Incompatible);
-        assert_eq!(observation.session.protocol, Some(999));
-        assert!(observation.agents.is_empty());
-        assert!(observation.targets.is_empty());
-        assert!(observation.pane_ids.is_empty());
         server.await.unwrap();
+        observation
     }
 
     #[tokio::test]
-    async fn herdr_v0_8_protocol_requests_and_parses_the_snapshot() {
+    async fn unsupported_protocols_never_request_or_surface_session_data() {
+        for protocol in [19, 999] {
+            let observation = observe_unsupported_protocol(protocol).await;
+            assert_eq!(observation.session.state, SessionState::Incompatible);
+            assert_eq!(observation.session.protocol, Some(protocol));
+            assert!(observation.agents.is_empty());
+            assert!(observation.targets.is_empty());
+            assert!(observation.pane_ids.is_empty());
+            assert_eq!(observation.agent_order, None);
+        }
+    }
+
+    #[tokio::test]
+    async fn herdr_v0_8_protocol_20_requests_and_parses_the_snapshot() {
         let temp = tempdir().unwrap();
         let socket = temp.path().join("herdr.sock");
         let listener = UnixListener::bind(&socket).unwrap();
@@ -721,7 +792,7 @@ mod tests {
             assert_eq!(request["method"], "ping");
             write
                 .write_all(
-                    b"{\"id\":\"ping\",\"result\":{\"version\":\"0.8.0\",\"protocol\":19}}\n",
+                    b"{\"id\":\"ping\",\"result\":{\"version\":\"0.8.0\",\"protocol\":20}}\n",
                 )
                 .await
                 .unwrap();
@@ -735,6 +806,19 @@ mod tests {
             write
                 .write_all(
                     b"{\"id\":\"snapshot\",\"result\":{\"snapshot\":{\"workspaces\":[{\"workspace_id\":\"w1\",\"number\":1,\"label\":\"xeneon\"}],\"tabs\":[{\"tab_id\":\"w1:t1\",\"label\":\"review\"}],\"agents\":[{\"terminal_id\":\"term-1\",\"agent\":\"codex\",\"agent_status\":\"blocked\",\"workspace_id\":\"w1\",\"tab_id\":\"w1:t1\",\"pane_id\":\"w1:p1\",\"revision\":4,\"state_change_seq\":9,\"actions\":[{\"capability_id\":\"interrupt-1\",\"action\":\"interrupt\",\"expires_at_unix_ms\":999,\"revision\":4}]}]}}}\n",
+                )
+                .await
+                .unwrap();
+
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, mut write) = stream.into_split();
+            let mut lines = BufReader::new(read).lines();
+            let request: Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            assert_eq!(request["method"], "agent.order.get");
+            write
+                .write_all(
+                    b"{\"id\":\"order\",\"result\":{\"type\":\"agent_order\",\"order\":\"grouped\"}}\n",
                 )
                 .await
                 .unwrap();
@@ -752,7 +836,8 @@ mod tests {
 
         assert_eq!(observation.session.state, SessionState::Connected);
         assert_eq!(observation.session.version.as_deref(), Some("0.8.0"));
-        assert_eq!(observation.session.protocol, Some(19));
+        assert_eq!(observation.session.protocol, Some(20));
+        assert_eq!(observation.agent_order, Some(AgentOrderMode::Grouped));
         assert_eq!(observation.agents.len(), 1);
         assert_eq!(observation.agents[0].display_name, "review");
         assert_eq!(observation.agents[0].status, AgentStatus::Blocked);
@@ -764,6 +849,115 @@ mod tests {
                 .map(|capability| capability.capability_id.as_str()),
             Some("interrupt-1")
         );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn missing_agent_order_api_disables_only_ordering() {
+        let temp = tempdir().unwrap();
+        let socket = temp.path().join("herdr.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = tokio::spawn(async move {
+            for (method, response) in [
+                (
+                    "ping",
+                    "{\"result\":{\"version\":\"0.8.0\",\"protocol\":20}}\n",
+                ),
+                (
+                    "session.snapshot",
+                    "{\"result\":{\"snapshot\":{\"workspaces\":[],\"tabs\":[],\"agents\":[]}}}\n",
+                ),
+                (
+                    "agent.order.get",
+                    "{\"error\":{\"code\":\"unknown_method\",\"message\":\"unsupported\"}}\n",
+                ),
+            ] {
+                let (stream, _) = listener.accept().await.unwrap();
+                let (read, mut write) = stream.into_split();
+                let mut lines = BufReader::new(read).lines();
+                let request: Value =
+                    serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+                assert_eq!(request["method"], method);
+                write.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+        let descriptor = SessionDescriptor {
+            name: "default".into(),
+            running: true,
+            socket_path: socket,
+        };
+
+        let observation = HerdrClient::new("herdr")
+            .observe_session(&descriptor, "epoch", 0, 1234)
+            .await
+            .unwrap();
+
+        assert_eq!(observation.session.state, SessionState::Connected);
+        assert_eq!(observation.agent_order, None);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn set_agent_order_sends_only_the_typed_idempotent_mode() {
+        let temp = tempdir().unwrap();
+        let socket = temp.path().join("herdr.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, mut write) = stream.into_split();
+            let mut lines = BufReader::new(read).lines();
+            let request: Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            assert_eq!(request["method"], "agent.order.set");
+            assert_eq!(request["params"], json!({"order": "priority"}));
+            assert!(request["params"].get("text").is_none());
+            assert!(request["params"].get("keys").is_none());
+            write
+                .write_all(b"{\"result\":{\"type\":\"agent_order\",\"order\":\"priority\"}}\n")
+                .await
+                .unwrap();
+        });
+        let descriptor = SessionDescriptor {
+            name: "default".into(),
+            running: true,
+            socket_path: socket,
+        };
+
+        HerdrClient::new("herdr")
+            .set_agent_order(&descriptor, AgentOrderMode::Priority)
+            .await
+            .unwrap();
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn get_agent_order_rejects_a_wrong_result_type() {
+        let temp = tempdir().unwrap();
+        let socket = temp.path().join("herdr.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, mut write) = stream.into_split();
+            let mut lines = BufReader::new(read).lines();
+            let request: Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            assert_eq!(request["method"], "agent.order.get");
+            write
+                .write_all(b"{\"result\":{\"type\":\"agent_view\",\"order\":\"grouped\"}}\n")
+                .await
+                .unwrap();
+        });
+        let descriptor = SessionDescriptor {
+            name: "default".into(),
+            running: true,
+            socket_path: socket,
+        };
+
+        let error = HerdrClient::new("herdr")
+            .get_agent_order(&descriptor)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("unexpected"));
         server.await.unwrap();
     }
 

--- a/crates/xeneon-agent-core/src/lib.rs
+++ b/crates/xeneon-agent-core/src/lib.rs
@@ -11,10 +11,10 @@ pub mod voice;
 
 pub use config::Config;
 pub use model::{
-    ActionCapability, ActionKind, ActionResult, AgentActions, AgentStatus, AgentView,
-    AiUsageSnapshot, ConnectionState, HealthSnapshot, Metric, MicroSnapshot, PortalCommand,
-    PortalSnapshot, ProviderUsage, ServerMessage, SessionState, SessionView, UsageKind,
-    UsageWindow, VoiceSnapshot, VoiceState,
+    ActionCapability, ActionKind, ActionResult, AgentActions, AgentOrderMode, AgentOrderSnapshot,
+    AgentStatus, AgentView, AiUsageSnapshot, ConnectionState, HealthSnapshot, Metric,
+    MicroSnapshot, PortalCommand, PortalSnapshot, ProviderUsage, ServerMessage, SessionState,
+    SessionView, UsageKind, UsageWindow, VoiceSnapshot, VoiceState,
 };
 pub use runtime::{DaemonRuntime, socket_path};
 pub use voice::cleanup_owned_dictation;

--- a/crates/xeneon-agent-core/src/model.rs
+++ b/crates/xeneon-agent-core/src/model.rs
@@ -78,6 +78,22 @@ pub enum ActionKind {
     VoiceStart,
     VoiceStop,
     VoiceCancel,
+    OrderGrouped,
+    OrderPriority,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentOrderMode {
+    #[default]
+    Grouped,
+    Priority,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentOrderSnapshot {
+    pub available: bool,
+    pub mode: AgentOrderMode,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -118,6 +134,8 @@ pub struct AgentView {
     pub session: String,
     pub focused: bool,
     pub observed_for_seconds: u64,
+    #[serde(default)]
+    pub state_change_seq: u64,
     pub source_order: usize,
     pub actions: AgentActions,
 }
@@ -189,6 +207,7 @@ pub fn sort_agents(agents: &mut [AgentView]) {
     agents.sort_by(|left, right| {
         agent_attention_rank(left)
             .cmp(&agent_attention_rank(right))
+            .then_with(|| right.state_change_seq.cmp(&left.state_change_seq))
             .then_with(|| left.source_order.cmp(&right.source_order))
             .then_with(|| left.id.cmp(&right.id))
     });
@@ -280,6 +299,8 @@ pub struct PortalSnapshot {
     pub connection: ConnectionState,
     pub sessions: Vec<SessionView>,
     pub agents: Vec<AgentView>,
+    #[serde(default)]
+    pub agent_order: AgentOrderSnapshot,
     pub voice: VoiceSnapshot,
     pub usage: AiUsageSnapshot,
     pub micro: MicroSnapshot,
@@ -296,6 +317,7 @@ impl PortalSnapshot {
             connection: ConnectionState::Offline,
             sessions: Vec::new(),
             agents: Vec::new(),
+            agent_order: AgentOrderSnapshot::default(),
             voice: VoiceSnapshot::default(),
             usage: AiUsageSnapshot::default(),
             micro: MicroSnapshot::default(),
@@ -375,13 +397,14 @@ mod tests {
             session: "default".into(),
             focused: false,
             observed_for_seconds: 0,
+            state_change_seq: 0,
             source_order,
             actions: AgentActions::default(),
         }
     }
 
     #[test]
-    fn attention_sort_preserves_source_order_within_status() {
+    fn attention_sort_uses_newest_change_then_source_order_within_status() {
         let mut done = agent("done", AgentStatus::Done, 1);
         done.review_ready = true;
         let mut agents = vec![
@@ -396,6 +419,14 @@ mod tests {
 
         let ids: Vec<_> = agents.iter().map(|agent| agent.id.as_str()).collect();
         assert_eq!(ids, ["blocked", "done", "working-1", "working-2", "idle"]);
+
+        let mut older = agent("older", AgentStatus::Working, 0);
+        older.state_change_seq = 3;
+        let mut newer = agent("newer", AgentStatus::Working, 1);
+        newer.state_change_seq = 9;
+        let mut tied = vec![older, newer];
+        sort_agents(&mut tied);
+        assert_eq!(tied[0].id, "newer");
     }
 
     #[test]

--- a/crates/xeneon-agent-core/src/protocol.rs
+++ b/crates/xeneon-agent-core/src/protocol.rs
@@ -32,7 +32,9 @@ pub fn validate_command(command: &PortalCommand) -> Result<(), CommandError> {
         | ActionKind::ClaudeDesktop
         | ActionKind::VoiceStart
         | ActionKind::VoiceStop
-        | ActionKind::VoiceCancel => {
+        | ActionKind::VoiceCancel
+        | ActionKind::OrderGrouped
+        | ActionKind::OrderPriority => {
             if command.agent_id.is_some() {
                 return Err(CommandError::UnexpectedAgentId);
             }
@@ -140,6 +142,24 @@ mod tests {
     }
 
     #[test]
+    fn order_actions_are_typed_global_actions() {
+        for action in [ActionKind::OrderGrouped, ActionKind::OrderPriority] {
+            let mut command = command(action);
+            assert_eq!(
+                validate_command(&command),
+                Err(CommandError::UnexpectedAgentId)
+            );
+            command.agent_id = None;
+            assert_eq!(validate_command(&command), Ok(()));
+            command.capability_id = Some("not-accepted".into());
+            assert_eq!(
+                validate_command(&command),
+                Err(CommandError::UnexpectedCapability)
+            );
+        }
+    }
+
+    #[test]
     fn capability_must_match_current_agent_snapshot() {
         let mut command = command(ActionKind::Approve);
         command.capability_id = Some("stale".into());
@@ -156,6 +176,7 @@ mod tests {
             session: "default".into(),
             focused: false,
             observed_for_seconds: 0,
+            state_change_seq: 0,
             source_order: 0,
             actions: AgentActions {
                 open: true,

--- a/crates/xeneon-agent-core/src/runtime.rs
+++ b/crates/xeneon-agent-core/src/runtime.rs
@@ -12,7 +12,7 @@ use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     net::{UnixListener, UnixStream},
     sync::{Mutex, RwLock, mpsc, watch},
-    task::JoinHandle,
+    task::{JoinHandle, spawn_blocking},
     time::{MissedTickBehavior, interval, sleep},
 };
 use uuid::Uuid;
@@ -24,9 +24,9 @@ use crate::{
     herdr::{AgentTarget, HerdrClient, SessionDescriptor},
     micro::MicroCollector,
     model::{
-        ActionKind, ActionResult, AgentActions, AgentStatus, ConnectionState, PortalCommand,
-        PortalSnapshot, SCHEMA_VERSION, ServerMessage, SessionState, SessionView, VoiceState,
-        sort_agents,
+        ActionKind, ActionResult, AgentActions, AgentOrderMode, AgentOrderSnapshot, AgentStatus,
+        ConnectionState, PortalCommand, PortalSnapshot, SCHEMA_VERSION, ServerMessage,
+        SessionState, SessionView, VoiceState, sort_agents,
     },
     protocol::{command_capability_matches, validate_command},
     usage::UsageCollector,
@@ -34,6 +34,18 @@ use crate::{
 };
 
 const INVALIDATION_COALESCE: Duration = Duration::from_millis(200);
+
+fn apply_agent_order(agents: &mut [crate::model::AgentView], order: &AgentOrderSnapshot) {
+    if order.available && order.mode == AgentOrderMode::Grouped {
+        agents.sort_by(|left, right| {
+            left.source_order
+                .cmp(&right.source_order)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+    } else {
+        sort_agents(agents);
+    }
+}
 
 #[derive(Debug)]
 struct RuntimeState {
@@ -66,6 +78,7 @@ pub struct DaemonRuntime {
     state: Arc<RwLock<RuntimeState>>,
     desktop: Arc<DesktopController>,
     voice: Arc<Mutex<VoiceController>>,
+    order_operation: Arc<Mutex<()>>,
     updates: watch::Sender<String>,
     invalidations: mpsc::Sender<String>,
 }
@@ -94,6 +107,7 @@ impl DaemonRuntime {
                 })),
                 desktop: Arc::new(desktop),
                 voice: Arc::new(Mutex::new(voice)),
+                order_operation: Arc::new(Mutex::new(())),
                 updates,
                 invalidations,
             },
@@ -108,6 +122,10 @@ impl DaemonRuntime {
         let auxiliary_runtime = self.clone();
         let mut auxiliary_collector = tokio::spawn(async move {
             auxiliary_runtime.collect_auxiliary_loop().await;
+        });
+        let usage_runtime = self.clone();
+        let mut usage_collector = tokio::spawn(async move {
+            usage_runtime.collect_usage_loop().await;
         });
         let herdr_runtime = self.clone();
         let mut herdr_collector = tokio::spawn(async move {
@@ -124,6 +142,10 @@ impl DaemonRuntime {
                     result.context("joining Herdr state collector")?;
                     bail!("Herdr state collector stopped unexpectedly");
                 }
+                result = &mut usage_collector => {
+                    result.context("joining usage state collector")?;
+                    bail!("usage state collector stopped unexpectedly");
+                }
                 accepted = listener.accept() => {
                     let (stream, _) = accepted.context("accepting portal client")?;
                     let client_runtime = self.clone();
@@ -139,15 +161,12 @@ impl DaemonRuntime {
 
     async fn collect_auxiliary_loop(&self) {
         let mut health = HealthCollector::default();
-        let usage = UsageCollector::default();
         let micro = MicroCollector::default();
         let mut health_tick = interval(self.config.health_refresh_interval());
         let mut voice_tick = interval(self.config.voice_refresh_interval());
-        let mut usage_tick = interval(self.config.usage_refresh_interval());
         let mut micro_tick = interval(self.config.micro_refresh_interval());
         health_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
         voice_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
-        usage_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
         micro_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {
@@ -165,16 +184,6 @@ impl DaemonRuntime {
                 _ = voice_tick.tick() => {
                     self.refresh_voice().await;
                 }
-                _ = usage_tick.tick() => {
-                    let sample = usage.sample();
-                    let mut state = self.state.write().await;
-                    if state.snapshot.usage != sample {
-                        state.snapshot.usage = sample;
-                        state.snapshot.generated_at_ms = now_ms();
-                        drop(state);
-                        self.publish().await;
-                    }
-                }
                 _ = micro_tick.tick() => {
                     let sample = micro.sample().await;
                     let mut state = self.state.write().await;
@@ -185,6 +194,31 @@ impl DaemonRuntime {
                         self.publish().await;
                     }
                 }
+            }
+        }
+    }
+
+    async fn collect_usage_loop(&self) {
+        let usage = UsageCollector::default();
+        let mut usage_tick = interval(self.config.usage_refresh_interval());
+        usage_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            usage_tick.tick().await;
+            let collector = usage.clone();
+            let sample = match spawn_blocking(move || collector.sample()).await {
+                Ok(sample) => sample,
+                Err(error) => {
+                    tracing::warn!(%error, "usage collector task failed");
+                    continue;
+                }
+            };
+            let mut state = self.state.write().await;
+            if state.snapshot.usage != sample {
+                state.snapshot.usage = sample;
+                state.snapshot.generated_at_ms = now_ms();
+                drop(state);
+                self.publish().await;
             }
         }
     }
@@ -232,6 +266,9 @@ impl DaemonRuntime {
     }
 
     async fn refresh_herdr(&self, subscriptions: &mut HashMap<String, Subscription>) {
+        // Keep a collected ordering snapshot from publishing after a completed
+        // ordering mutation, and serialize collection with compensating writes.
+        let _order_guard = self.order_operation.lock().await;
         let observation_time_ms = now_ms();
         let descriptors = match self.herdr.discover().await {
             Ok(descriptors) => descriptors,
@@ -246,6 +283,8 @@ impl DaemonRuntime {
                 for agent in &mut state.snapshot.agents {
                     agent.actions = AgentActions::default();
                 }
+                state.snapshot.agent_order = AgentOrderSnapshot::default();
+                sort_agents(&mut state.snapshot.agents);
                 state.targets.clear();
                 state.snapshot.sequence = state.snapshot.sequence.saturating_add(1);
                 state.snapshot.generated_at_ms = now_ms();
@@ -261,6 +300,7 @@ impl DaemonRuntime {
         let mut agents = Vec::new();
         let mut targets = HashMap::new();
         let mut connected = 0usize;
+        let mut order_modes = Vec::new();
         let mut source_offset = 0usize;
         let mut active_names = Vec::new();
 
@@ -367,6 +407,9 @@ impl DaemonRuntime {
                         }
                     }
                     connected += 1;
+                    if let Some(mode) = observation.agent_order {
+                        order_modes.push(mode);
+                    }
                     source_offset += observation.agents.len();
                     sessions.push(observation.session);
                     targets.extend(observation.targets);
@@ -415,9 +458,22 @@ impl DaemonRuntime {
             ..
         } = &mut *state;
         apply_agent_observations(&mut agents, &targets, observed, focused_agents, now);
-        sort_agents(&mut agents);
+        let agent_order = if !descriptors.is_empty()
+            && connected == descriptors.len()
+            && order_modes.len() == connected
+            && order_modes.iter().all(|mode| *mode == order_modes[0])
+        {
+            AgentOrderSnapshot {
+                available: true,
+                mode: order_modes[0],
+            }
+        } else {
+            AgentOrderSnapshot::default()
+        };
+        apply_agent_order(&mut agents, &agent_order);
         state.snapshot.sessions = sessions;
         state.snapshot.agents = agents;
+        state.snapshot.agent_order = agent_order;
         state.snapshot.connection = if descriptors.is_empty() {
             ConnectionState::Offline
         } else if connected == descriptors.len() {
@@ -542,6 +598,13 @@ impl DaemonRuntime {
             return self.process_voice_command(&command, client_id).await;
         }
 
+        if matches!(
+            command.action,
+            ActionKind::OrderGrouped | ActionKind::OrderPriority
+        ) {
+            return self.process_agent_order_command(&command).await;
+        }
+
         let (snapshot_sequence, agent, target) = {
             let state = self.state.read().await;
             (
@@ -589,7 +652,9 @@ impl DaemonRuntime {
             | ActionKind::ClaudeDesktop
             | ActionKind::VoiceStart
             | ActionKind::VoiceStop
-            | ActionKind::VoiceCancel => true,
+            | ActionKind::VoiceCancel
+            | ActionKind::OrderGrouped
+            | ActionKind::OrderPriority => true,
         };
         if !enabled {
             return action_error(
@@ -649,6 +714,152 @@ impl DaemonRuntime {
                 action_error(&command.request_id, code, public_message)
             }
         }
+    }
+
+    async fn process_agent_order_command(&self, command: &PortalCommand) -> ActionResult {
+        let _order_guard = self.order_operation.lock().await;
+        let authoritative = self.state.read().await.snapshot.agent_order.clone();
+        let sequence = self.state.read().await.snapshot.sequence;
+        if command.sequence != sequence || !authoritative.available {
+            return action_error(
+                &command.request_id,
+                "stale_snapshot",
+                "the authoritative Herdr ordering changed before the action",
+            );
+        }
+        let mode = match command.action {
+            ActionKind::OrderGrouped => AgentOrderMode::Grouped,
+            ActionKind::OrderPriority => AgentOrderMode::Priority,
+            _ => unreachable!("ordering command filtered before dispatch"),
+        };
+        let descriptors = match self.herdr.discover().await {
+            Ok(descriptors) if !descriptors.is_empty() => descriptors,
+            Ok(_) => {
+                return action_error(
+                    &command.request_id,
+                    "session_disconnected",
+                    "no running Herdr session can change agent ordering",
+                );
+            }
+            Err(error) => {
+                tracing::warn!(%error, "Herdr discovery failed for agent ordering");
+                return action_error(
+                    &command.request_id,
+                    "session_disconnected",
+                    "Herdr agent ordering is unavailable",
+                );
+            }
+        };
+
+        let mut prior_modes = Vec::with_capacity(descriptors.len());
+        for descriptor in &descriptors {
+            match self.herdr.get_agent_order(descriptor).await {
+                Ok(prior) => prior_modes.push((descriptor.clone(), prior)),
+                Err(error) => {
+                    tracing::warn!(session = %descriptor.name, %error, "Herdr agent ordering preflight failed");
+                    let _ = self.invalidations.try_send(descriptor.name.clone());
+                    return action_error(
+                        &command.request_id,
+                        "target_unavailable",
+                        "Herdr could not verify agent ordering",
+                    );
+                }
+            }
+        }
+        if prior_modes
+            .iter()
+            .any(|(_, prior)| *prior != authoritative.mode)
+        {
+            for (descriptor, _) in &prior_modes {
+                let _ = self.invalidations.try_send(descriptor.name.clone());
+            }
+            return action_error(
+                &command.request_id,
+                "stale_snapshot",
+                "Herdr ordering changed before the action",
+            );
+        }
+
+        let mut attempted = Vec::new();
+        for (descriptor, prior) in &prior_modes {
+            if *prior == mode {
+                continue;
+            }
+            // A failed response is ambiguous: Herdr may have persisted the
+            // idempotent SET before the socket closed. Compensate every
+            // attempted descriptor, including the one returning the error.
+            attempted.push((descriptor.clone(), *prior));
+            if let Err(error) = self.herdr.set_agent_order(descriptor, mode).await {
+                tracing::warn!(session = %descriptor.name, %error, "Herdr agent ordering failed");
+                let mut compensated = true;
+                for (changed_descriptor, changed_prior) in attempted.iter().rev() {
+                    if let Err(compensation_error) = self
+                        .herdr
+                        .set_agent_order(changed_descriptor, *changed_prior)
+                        .await
+                    {
+                        compensated = false;
+                        tracing::error!(
+                            session = %changed_descriptor.name,
+                            %compensation_error,
+                            "Herdr agent ordering compensation failed"
+                        );
+                    }
+                }
+                for (checked_descriptor, checked_prior) in &prior_modes {
+                    match self.herdr.get_agent_order(checked_descriptor).await {
+                        Ok(actual) if actual == *checked_prior => {}
+                        Ok(actual) => {
+                            compensated = false;
+                            tracing::error!(
+                                session = %checked_descriptor.name,
+                                ?actual,
+                                expected = ?checked_prior,
+                                "Herdr ordering differs after compensation"
+                            );
+                        }
+                        Err(check_error) => {
+                            compensated = false;
+                            tracing::error!(
+                                session = %checked_descriptor.name,
+                                %check_error,
+                                "Herdr ordering compensation could not be verified"
+                            );
+                        }
+                    }
+                    let _ = self.invalidations.try_send(checked_descriptor.name.clone());
+                }
+                if !compensated {
+                    let mut state = self.state.write().await;
+                    state.snapshot.agent_order = AgentOrderSnapshot::default();
+                    state.snapshot.sequence = state.snapshot.sequence.saturating_add(1);
+                    state.snapshot.generated_at_ms = now_ms();
+                    drop(state);
+                    self.publish().await;
+                }
+                return action_error(
+                    &command.request_id,
+                    "target_unavailable",
+                    "Herdr could not synchronize agent ordering",
+                );
+            }
+        }
+
+        let mut state = self.state.write().await;
+        state.snapshot.agent_order = AgentOrderSnapshot {
+            available: true,
+            mode,
+        };
+        let ordering = state.snapshot.agent_order.clone();
+        apply_agent_order(&mut state.snapshot.agents, &ordering);
+        state.snapshot.sequence = state.snapshot.sequence.saturating_add(1);
+        state.snapshot.generated_at_ms = now_ms();
+        drop(state);
+        self.publish().await;
+        for descriptor in &descriptors {
+            let _ = self.invalidations.try_send(descriptor.name.clone());
+        }
+        action_ok(&command.request_id, "agent_order_updated")
     }
 
     async fn process_voice_command(
@@ -1010,6 +1221,375 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&encoded).unwrap();
         assert_eq!(value["type"], "snapshot");
         assert_eq!(value["voice"]["state"], "unavailable");
+        assert_eq!(value["agent_order"]["available"], false);
+    }
+
+    #[test]
+    fn agent_order_uses_source_order_for_grouped_and_attention_for_priority() {
+        let mut agents = vec![
+            AgentView {
+                source_order: 0,
+                ..test_agent("workspace-first", AgentStatus::Idle, false)
+            },
+            AgentView {
+                source_order: 1,
+                ..test_agent("attention-first", AgentStatus::Blocked, false)
+            },
+        ];
+        apply_agent_order(
+            &mut agents,
+            &AgentOrderSnapshot {
+                available: true,
+                mode: AgentOrderMode::Grouped,
+            },
+        );
+        assert_eq!(agents[0].id, "workspace-first");
+        apply_agent_order(
+            &mut agents,
+            &AgentOrderSnapshot {
+                available: true,
+                mode: AgentOrderMode::Priority,
+            },
+        );
+        assert_eq!(agents[0].id, "attention-first");
+    }
+
+    #[tokio::test]
+    async fn discovery_failure_clears_stale_ordering_and_restores_fallback_sort() {
+        let temp = tempfile::tempdir().unwrap();
+        let binary = temp.path().join("herdr");
+        fs::write(&binary, "#!/bin/sh\nexit 1\n").unwrap();
+        fs::set_permissions(&binary, fs::Permissions::from_mode(0o700)).unwrap();
+        let (runtime, _) = DaemonRuntime::new(Config {
+            herdr_bin: binary,
+            ..Config::default()
+        })
+        .unwrap();
+        {
+            let mut state = runtime.state.write().await;
+            state.snapshot.agent_order = AgentOrderSnapshot {
+                available: true,
+                mode: AgentOrderMode::Grouped,
+            };
+            state.snapshot.agents = vec![
+                AgentView {
+                    source_order: 0,
+                    ..test_agent("workspace-first", AgentStatus::Idle, false)
+                },
+                AgentView {
+                    source_order: 1,
+                    ..test_agent("attention-first", AgentStatus::Blocked, false)
+                },
+            ];
+        }
+
+        runtime.refresh_herdr(&mut HashMap::new()).await;
+
+        let state = runtime.state.read().await;
+        assert_eq!(state.snapshot.connection, ConnectionState::Offline);
+        assert!(!state.snapshot.agent_order.available);
+        assert_eq!(state.snapshot.agents[0].id, "attention-first");
+    }
+
+    #[tokio::test]
+    async fn order_command_updates_herdr_and_the_published_card_order_once() {
+        let temp = tempfile::tempdir().unwrap();
+        let socket = temp.path().join("herdr.sock");
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, mut write) = stream.into_split();
+            let mut lines = BufReader::new(read).lines();
+            let request: serde_json::Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            assert_eq!(request["method"], "agent.order.get");
+            write
+                .write_all(b"{\"result\":{\"type\":\"agent_order\",\"order\":\"grouped\"}}\n")
+                .await
+                .unwrap();
+
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, mut write) = stream.into_split();
+            let mut lines = BufReader::new(read).lines();
+            let request: serde_json::Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            assert_eq!(request["method"], "agent.order.set");
+            assert_eq!(request["params"], serde_json::json!({"order": "priority"}));
+            write
+                .write_all(b"{\"result\":{\"type\":\"agent_order\",\"order\":\"priority\"}}\n")
+                .await
+                .unwrap();
+        });
+        let binary = temp.path().join("herdr");
+        let session_list = serde_json::json!({
+            "sessions": [{
+                "name": "default",
+                "running": true,
+                "socket_path": socket
+            }]
+        });
+        fs::write(
+            &binary,
+            format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", session_list),
+        )
+        .unwrap();
+        fs::set_permissions(&binary, fs::Permissions::from_mode(0o700)).unwrap();
+        let config = Config {
+            herdr_bin: binary,
+            ..Config::default()
+        };
+        let (runtime, _) = DaemonRuntime::new(config).unwrap();
+        {
+            let mut state = runtime.state.write().await;
+            state.snapshot.sequence = 7;
+            state.snapshot.agent_order = AgentOrderSnapshot {
+                available: true,
+                mode: AgentOrderMode::Grouped,
+            };
+            state.snapshot.agents = vec![
+                AgentView {
+                    source_order: 0,
+                    ..test_agent("workspace-first", AgentStatus::Idle, false)
+                },
+                AgentView {
+                    source_order: 1,
+                    ..test_agent("attention-first", AgentStatus::Blocked, false)
+                },
+            ];
+        }
+        let result = runtime
+            .process_agent_order_command(&PortalCommand {
+                schema_version: SCHEMA_VERSION,
+                request_id: "order".into(),
+                sequence: 7,
+                agent_id: None,
+                action: ActionKind::OrderPriority,
+                capability_id: None,
+            })
+            .await;
+
+        assert!(result.ok);
+        let state = runtime.state.read().await;
+        assert!(state.snapshot.agent_order.available);
+        assert_eq!(state.snapshot.agent_order.mode, AgentOrderMode::Priority);
+        assert_eq!(state.snapshot.agents[0].id, "attention-first");
+        assert_eq!(state.snapshot.sequence, 8);
+        drop(state);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn order_command_compensates_a_partial_multi_session_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let first_socket = temp.path().join("first.sock");
+        let second_socket = temp.path().join("second.sock");
+        let first_listener = tokio::net::UnixListener::bind(&first_socket).unwrap();
+        let second_listener = tokio::net::UnixListener::bind(&second_socket).unwrap();
+
+        let first = tokio::spawn(async move {
+            for (method, order, response) in [
+                (
+                    "agent.order.get",
+                    None,
+                    "{\"result\":{\"type\":\"agent_order\",\"order\":\"grouped\"}}\n",
+                ),
+                (
+                    "agent.order.set",
+                    Some("priority"),
+                    "{\"result\":{\"type\":\"agent_order\",\"order\":\"priority\"}}\n",
+                ),
+                (
+                    "agent.order.set",
+                    Some("grouped"),
+                    "{\"result\":{\"type\":\"agent_order\",\"order\":\"grouped\"}}\n",
+                ),
+                (
+                    "agent.order.get",
+                    None,
+                    "{\"result\":{\"type\":\"agent_order\",\"order\":\"grouped\"}}\n",
+                ),
+            ] {
+                let (stream, _) = first_listener.accept().await.unwrap();
+                let (read, mut write) = stream.into_split();
+                let mut lines = BufReader::new(read).lines();
+                let request: serde_json::Value =
+                    serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+                assert_eq!(request["method"], method);
+                if let Some(order) = order {
+                    assert_eq!(request["params"]["order"], order);
+                }
+                write.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+        let second = tokio::spawn(async move {
+            for (method, order, response) in [
+                (
+                    "agent.order.get",
+                    None,
+                    "{\"result\":{\"type\":\"agent_order\",\"order\":\"grouped\"}}\n",
+                ),
+                ("agent.order.set", Some("priority"), ""),
+                (
+                    "agent.order.set",
+                    Some("grouped"),
+                    "{\"result\":{\"type\":\"agent_order\",\"order\":\"grouped\"}}\n",
+                ),
+                (
+                    "agent.order.get",
+                    None,
+                    "{\"result\":{\"type\":\"agent_order\",\"order\":\"grouped\"}}\n",
+                ),
+            ] {
+                let (stream, _) = second_listener.accept().await.unwrap();
+                let (read, mut write) = stream.into_split();
+                let mut lines = BufReader::new(read).lines();
+                let request: serde_json::Value =
+                    serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+                assert_eq!(request["method"], method);
+                if let Some(order) = order {
+                    assert_eq!(request["params"]["order"], order);
+                }
+                write.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        let binary = temp.path().join("herdr");
+        let session_list = serde_json::json!({
+            "sessions": [
+                {"name": "first", "running": true, "socket_path": first_socket},
+                {"name": "second", "running": true, "socket_path": second_socket}
+            ]
+        });
+        fs::write(
+            &binary,
+            format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", session_list),
+        )
+        .unwrap();
+        fs::set_permissions(&binary, fs::Permissions::from_mode(0o700)).unwrap();
+        let (runtime, _) = DaemonRuntime::new(Config {
+            herdr_bin: binary,
+            ..Config::default()
+        })
+        .unwrap();
+        {
+            let mut state = runtime.state.write().await;
+            state.snapshot.sequence = 7;
+            state.snapshot.agent_order = AgentOrderSnapshot {
+                available: true,
+                mode: AgentOrderMode::Grouped,
+            };
+        }
+
+        let result = runtime
+            .process_agent_order_command(&PortalCommand {
+                schema_version: SCHEMA_VERSION,
+                request_id: "order-partial".into(),
+                sequence: 7,
+                agent_id: None,
+                action: ActionKind::OrderPriority,
+                capability_id: None,
+            })
+            .await;
+
+        assert!(!result.ok);
+        assert_eq!(result.code, "target_unavailable");
+        let state = runtime.state.read().await;
+        assert_eq!(state.snapshot.sequence, 7);
+        assert_eq!(state.snapshot.agent_order.mode, AgentOrderMode::Grouped);
+        assert!(state.snapshot.agent_order.available);
+        drop(state);
+        first.await.unwrap();
+        second.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn concurrent_order_commands_serialize_and_recheck_sequence() {
+        let temp = tempfile::tempdir().unwrap();
+        let socket = temp.path().join("herdr.sock");
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        let (preflight_started_tx, preflight_started_rx) = tokio::sync::oneshot::channel();
+        let (release_preflight_tx, release_preflight_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, mut write) = stream.into_split();
+            let mut lines = BufReader::new(read).lines();
+            let request: serde_json::Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            assert_eq!(request["method"], "agent.order.get");
+            preflight_started_tx.send(()).unwrap();
+            release_preflight_rx.await.unwrap();
+            write
+                .write_all(b"{\"result\":{\"type\":\"agent_order\",\"order\":\"grouped\"}}\n")
+                .await
+                .unwrap();
+
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, mut write) = stream.into_split();
+            let mut lines = BufReader::new(read).lines();
+            let request: serde_json::Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            assert_eq!(request["method"], "agent.order.set");
+            write
+                .write_all(b"{\"result\":{\"type\":\"agent_order\",\"order\":\"priority\"}}\n")
+                .await
+                .unwrap();
+        });
+        let binary = temp.path().join("herdr");
+        let session_list = serde_json::json!({
+            "sessions": [{"name": "default", "running": true, "socket_path": socket}]
+        });
+        fs::write(
+            &binary,
+            format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", session_list),
+        )
+        .unwrap();
+        fs::set_permissions(&binary, fs::Permissions::from_mode(0o700)).unwrap();
+        let (runtime, _) = DaemonRuntime::new(Config {
+            herdr_bin: binary,
+            ..Config::default()
+        })
+        .unwrap();
+        {
+            let mut state = runtime.state.write().await;
+            state.snapshot.sequence = 7;
+            state.snapshot.agent_order = AgentOrderSnapshot {
+                available: true,
+                mode: AgentOrderMode::Grouped,
+            };
+        }
+        let command = PortalCommand {
+            schema_version: SCHEMA_VERSION,
+            request_id: "first".into(),
+            sequence: 7,
+            agent_id: None,
+            action: ActionKind::OrderPriority,
+            capability_id: None,
+        };
+        let first_runtime = runtime.clone();
+        let first =
+            tokio::spawn(async move { first_runtime.process_agent_order_command(&command).await });
+        preflight_started_rx.await.unwrap();
+        let second_runtime = runtime.clone();
+        let second = tokio::spawn(async move {
+            second_runtime
+                .process_agent_order_command(&PortalCommand {
+                    schema_version: SCHEMA_VERSION,
+                    request_id: "second".into(),
+                    sequence: 7,
+                    agent_id: None,
+                    action: ActionKind::OrderPriority,
+                    capability_id: None,
+                })
+                .await
+        });
+        release_preflight_tx.send(()).unwrap();
+
+        assert!(first.await.unwrap().ok);
+        let second = second.await.unwrap();
+        assert!(!second.ok);
+        assert_eq!(second.code, "stale_snapshot");
+        assert_eq!(runtime.state.read().await.snapshot.sequence, 8);
+        server.await.unwrap();
     }
 
     #[test]
@@ -1203,6 +1783,7 @@ mod tests {
             session: "default".into(),
             focused,
             observed_for_seconds: 0,
+            state_change_seq: 0,
             source_order: 0,
             actions: AgentActions::default(),
         }

--- a/crates/xeneon-agent-core/src/usage.rs
+++ b/crates/xeneon-agent-core/src/usage.rs
@@ -1,60 +1,108 @@
 use std::{
     env, fs,
+    io::Read,
     path::{Path, PathBuf},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
+use rusqlite::{Connection, OpenFlags, types::Value as SqlValue};
 use serde_json::Value;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::model::{AiUsageSnapshot, ProviderUsage, UsageKind, UsageWindow};
 
 const FRESH_FOR: Duration = Duration::from_secs(15 * 60);
 const MAX_CACHE_BYTES: u64 = 64 * 1024;
 const MAX_AGGREGATE_TOKENS: u64 = 1_000_000_000_000_000;
+const MAX_OPENCODE_ROWS: usize = 100_000;
+const OPENCODE_BUSY_TIMEOUT: Duration = Duration::from_millis(250);
+const OPENCODE_QUERY_BUDGET: Duration = Duration::from_millis(500);
+const OPENCODE_5H_LIMIT: u64 = 1_000_000;
+const OPENCODE_7D_LIMIT: u64 = 20_000_000;
+const FIVE_HOURS_MS: u64 = 5 * 60 * 60 * 1_000;
+const SEVEN_DAYS_MS: u64 = 7 * 24 * 60 * 60 * 1_000;
+const ONE_HOUR_MS: u64 = 60 * 60 * 1_000;
 
 #[derive(Debug, Clone)]
 pub struct UsageCollector {
-    cache_dir: PathBuf,
+    legacy_cache_dir: PathBuf,
+    state_usage_dir: PathBuf,
+    opencode_db: PathBuf,
 }
 
 impl Default for UsageCollector {
     fn default() -> Self {
-        let cache_dir = env::var_os("XDG_CACHE_HOME")
+        let home = env::var_os("HOME").map(PathBuf::from);
+        let legacy_cache_dir = env::var_os("XDG_CACHE_HOME")
             .map(PathBuf::from)
-            .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".cache")))
+            .or_else(|| home.as_ref().map(|home| home.join(".cache")))
             .unwrap_or_else(|| PathBuf::from(".cache"));
-        Self { cache_dir }
+        let state_usage_dir = env::var_os("XDG_STATE_HOME")
+            .map(PathBuf::from)
+            .or_else(|| home.as_ref().map(|home| home.join(".local/state")))
+            .unwrap_or_else(|| PathBuf::from(".local/state"))
+            .join("omarchy/agents/usage");
+        let opencode_db = env::var_os("XDG_DATA_HOME")
+            .map(PathBuf::from)
+            .or_else(|| home.as_ref().map(|home| home.join(".local/share")))
+            .unwrap_or_else(|| PathBuf::from(".local/share"))
+            .join("opencode/opencode.db");
+        Self {
+            legacy_cache_dir,
+            state_usage_dir,
+            opencode_db,
+        }
     }
 }
 
 impl UsageCollector {
-    pub fn new(cache_dir: impl Into<PathBuf>) -> Self {
+    #[cfg(test)]
+    fn legacy_only(cache_dir: impl Into<PathBuf>) -> Self {
+        let legacy_cache_dir = cache_dir.into();
         Self {
-            cache_dir: cache_dir.into(),
+            state_usage_dir: legacy_cache_dir.join("missing-state-records"),
+            opencode_db: legacy_cache_dir.join("missing-opencode.db"),
+            legacy_cache_dir,
         }
     }
 
     pub fn sample(&self) -> AiUsageSnapshot {
         AiUsageSnapshot {
             providers: vec![
-                self.read_provider("claude", "Claude", UsageKind::Quota),
-                self.read_provider("codex", "Codex", UsageKind::Quota),
-                self.read_provider("opencode", "OpenCode", UsageKind::LocalBudget),
+                self.read_quota_provider("claude", "Claude"),
+                self.read_quota_provider("codex", "Codex"),
+                self.read_opencode(),
             ],
         }
     }
 
-    fn read_provider(&self, id: &str, label: &str, kind: UsageKind) -> ProviderUsage {
-        let path = self.cache_dir.join(format!("{id}-usage.json"));
+    fn read_quota_provider(&self, id: &str, label: &str) -> ProviderUsage {
+        let normalized_path = self.state_usage_dir.join(format!("{id}.json"));
+        if normalized_path.exists() {
+            return read_omarchy_provider(&normalized_path, id, label);
+        }
+        self.read_legacy_provider(id, label, UsageKind::Quota)
+    }
+
+    fn read_opencode(&self) -> ProviderUsage {
+        let database = read_opencode_db(&self.opencode_db);
+        if database.available {
+            return database;
+        }
+        let legacy_path = self.legacy_cache_dir.join("opencode-usage.json");
+        if legacy_path.exists() {
+            return self.read_legacy_provider("opencode", "OpenCode", UsageKind::LocalBudget);
+        }
+        database
+    }
+
+    fn read_legacy_provider(&self, id: &str, label: &str, kind: UsageKind) -> ProviderUsage {
+        let path = self.legacy_cache_dir.join(format!("{id}-usage.json"));
         let last_updated_ms = modified_ms(&path);
         let stale_by_age = last_updated_ms
             .and_then(|updated| now_ms().checked_sub(updated))
             .is_none_or(|age| age > FRESH_FOR.as_millis() as u64);
-        let value = fs::metadata(&path)
-            .ok()
-            .filter(|metadata| metadata.len() <= MAX_CACHE_BYTES)
-            .and_then(|_| fs::read_to_string(&path).ok())
-            .and_then(|contents| serde_json::from_str::<Value>(&contents).ok());
+        let value = read_bounded_json(&path);
         let Some(value) = value else {
             return unavailable_provider(id, label, kind, last_updated_ms);
         };
@@ -98,6 +146,311 @@ impl UsageCollector {
         }
         provider
     }
+}
+
+fn read_omarchy_provider(path: &Path, id: &str, label: &str) -> ProviderUsage {
+    let last_updated_ms = modified_ms(path);
+    let stale = stale_by_age(last_updated_ms);
+    let value = read_bounded_json(path);
+    let Some(value) = value else {
+        return unavailable_provider(id, label, UsageKind::Quota, last_updated_ms);
+    };
+    let trusted_record = value.get("schemaVersion").and_then(Value::as_u64) == Some(1)
+        && value.get("id").and_then(Value::as_str) == Some(id)
+        && value.get("ready").and_then(Value::as_bool) == Some(true)
+        && value
+            .get("usageStatusText")
+            .and_then(Value::as_str)
+            .is_some_and(|status| status.trim().is_empty());
+    if !trusted_record {
+        return unavailable_provider(id, label, UsageKind::Quota, last_updated_ms);
+    }
+
+    let windows = value
+        .get("limits")
+        .and_then(Value::as_array)
+        .map(|limits| {
+            limits
+                .iter()
+                .filter_map(omarchy_window)
+                .take(2)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let primary = windows.first().cloned();
+    let secondary = windows.get(1).cloned();
+    if primary.is_none() && secondary.is_none() {
+        return unavailable_provider(id, label, UsageKind::Quota, last_updated_ms);
+    }
+
+    ProviderUsage {
+        id: id.into(),
+        label: label.into(),
+        kind: UsageKind::Quota,
+        available: true,
+        stale,
+        source: "omarchy".into(),
+        status: "allowed".into(),
+        plan: bounded(value.get("tierLabel").and_then(Value::as_str), 32),
+        model: None,
+        primary,
+        secondary,
+        today_tokens: aggregate_tokens(value.get("todayTotalTokens")),
+        tokens_per_hour: None,
+        last_updated_ms,
+    }
+}
+
+fn omarchy_window(value: &Value) -> Option<UsageWindow> {
+    let utilization = numeric(value.get("percent"))?.clamp(0.0, 1.0);
+    let label = bounded(value.get("label").and_then(Value::as_str), 24)?;
+    let reset_at_ms = value
+        .get("resetsAt")
+        .and_then(Value::as_str)
+        .and_then(parse_rfc3339_ms);
+    Some(UsageWindow {
+        label,
+        utilization,
+        reset_at_ms,
+    })
+}
+
+fn parse_rfc3339_ms(value: &str) -> Option<u64> {
+    let timestamp = OffsetDateTime::parse(value, &Rfc3339)
+        .ok()?
+        .unix_timestamp_nanos();
+    u64::try_from(timestamp / 1_000_000).ok()
+}
+
+fn read_bounded_json(path: &Path) -> Option<Value> {
+    let file = fs::File::open(path).ok()?;
+    let metadata = file.metadata().ok()?;
+    if !metadata.is_file() || metadata.len() > MAX_CACHE_BYTES {
+        return None;
+    }
+    let mut contents = Vec::with_capacity((metadata.len() as usize).min(MAX_CACHE_BYTES as usize));
+    file.take(MAX_CACHE_BYTES.saturating_add(1))
+        .read_to_end(&mut contents)
+        .ok()?;
+    if contents.len() > MAX_CACHE_BYTES as usize {
+        return None;
+    }
+    serde_json::from_slice(&contents).ok()
+}
+
+#[derive(Debug)]
+struct OpenCodeMessage {
+    updated_ms: u64,
+    tokens: u64,
+    model: Option<String>,
+}
+
+fn read_opencode_db(path: &Path) -> ProviderUsage {
+    let fallback_updated_ms = modified_ms(path);
+    let Some((tokens_5h, tokens_7d, tokens_1h, Some(latest))) = collect_opencode_usage(path) else {
+        return unavailable_provider(
+            "opencode",
+            "OpenCode",
+            UsageKind::LocalBudget,
+            fallback_updated_ms,
+        );
+    };
+    let last_updated_ms = Some(latest.updated_ms);
+    let status = if tokens_5h >= OPENCODE_5H_LIMIT.saturating_mul(9) / 10 {
+        "allowed_warning"
+    } else {
+        "allowed"
+    };
+    ProviderUsage {
+        id: "opencode".into(),
+        label: "OpenCode".into(),
+        kind: UsageKind::LocalBudget,
+        available: true,
+        stale: stale_by_age(last_updated_ms),
+        source: "sqlite".into(),
+        status: status.into(),
+        plan: Some("local messages".into()),
+        model: latest.model,
+        primary: Some(UsageWindow {
+            label: "5h".into(),
+            utilization: (tokens_5h as f64 / OPENCODE_5H_LIMIT as f64).clamp(0.0, 1.0),
+            reset_at_ms: None,
+        }),
+        secondary: Some(UsageWindow {
+            label: "Weekly".into(),
+            utilization: (tokens_7d as f64 / OPENCODE_7D_LIMIT as f64).clamp(0.0, 1.0),
+            reset_at_ms: None,
+        }),
+        today_tokens: None,
+        tokens_per_hour: Some(tokens_1h),
+        last_updated_ms,
+    }
+}
+
+fn collect_opencode_usage(path: &Path) -> Option<(u64, u64, u64, Option<OpenCodeMessage>)> {
+    collect_opencode_usage_bounded(path, MAX_OPENCODE_ROWS, OPENCODE_QUERY_BUDGET)
+}
+
+fn collect_opencode_usage_bounded(
+    path: &Path,
+    max_rows: usize,
+    query_budget: Duration,
+) -> Option<(u64, u64, u64, Option<OpenCodeMessage>)> {
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()?;
+    connection.busy_timeout(OPENCODE_BUSY_TIMEOUT).ok()?;
+    let deadline = Instant::now().checked_add(query_budget)?;
+    connection
+        .progress_handler(10_000, Some(move || Instant::now() >= deadline))
+        .ok()?;
+    let now = now_ms();
+    let mut statement = connection
+        .prepare(
+            "SELECT time_created, time_updated, \
+                substr(CASE WHEN length(CAST(data AS BLOB)) <= ?2 AND json_valid(data) THEN json_extract(data, '$.role') END, 1, 10), \
+                substr(CASE WHEN length(CAST(data AS BLOB)) <= ?2 AND json_valid(data) THEN json_extract(data, '$.modelID') END, 1, 49), \
+                substr(CASE WHEN length(CAST(data AS BLOB)) <= ?2 AND json_valid(data) THEN json_extract(data, '$.providerID') END, 1, 25), \
+                CASE WHEN length(CAST(data AS BLOB)) <= ?2 AND json_valid(data) THEN json_extract(data, '$.tokens.input') END, \
+                CASE WHEN length(CAST(data AS BLOB)) <= ?2 AND json_valid(data) THEN json_extract(data, '$.tokens.output') END, \
+                CASE WHEN length(CAST(data AS BLOB)) <= ?2 AND json_valid(data) THEN json_extract(data, '$.tokens.reasoning') END, \
+                CASE WHEN length(CAST(data AS BLOB)) <= ?2 AND json_valid(data) THEN json_extract(data, '$.tokens.cache.write') END \
+             FROM message \
+             WHERE time_updated >= ?3 OR time_created >= ?3 \
+             ORDER BY rowid DESC LIMIT ?1",
+        )
+        .ok()?;
+    let mut rows = statement
+        .query(rusqlite::params![
+            i64::try_from(max_rows.saturating_add(1)).ok()?,
+            i64::try_from(MAX_CACHE_BYTES).ok()?,
+            i64::try_from(now.saturating_sub(SEVEN_DAYS_MS)).ok()?
+        ])
+        .ok()?;
+    let mut row_count = 0usize;
+    let mut tokens_5h = 0u64;
+    let mut tokens_7d = 0u64;
+    let mut tokens_1h = 0u64;
+    let mut latest = None;
+    while let Some(row) = rows.next().ok()? {
+        row_count = row_count.saturating_add(1);
+        if row_count > max_rows {
+            return None;
+        }
+        let time_created = row.get::<_, i64>(0).ok()?;
+        let time_updated = row.get::<_, i64>(1).ok()?;
+        let role = row.get::<_, Option<String>>(2).ok()?;
+        let model_id = row.get::<_, Option<String>>(3).ok()?;
+        let provider_id = row.get::<_, Option<String>>(4).ok()?;
+        let token_values = [
+            row.get::<_, SqlValue>(5).ok()?,
+            row.get::<_, SqlValue>(6).ok()?,
+            row.get::<_, SqlValue>(7).ok()?,
+            row.get::<_, SqlValue>(8).ok()?,
+        ];
+        let Some(message) = parse_opencode_scalars(
+            time_created,
+            time_updated,
+            role.as_deref(),
+            model_id.as_deref(),
+            provider_id.as_deref(),
+            &token_values,
+        ) else {
+            continue;
+        };
+        if message.updated_ms > now.saturating_add(FRESH_FOR.as_millis() as u64) {
+            continue;
+        }
+        if message.updated_ms < now.saturating_sub(SEVEN_DAYS_MS) {
+            continue;
+        }
+        tokens_7d = bounded_add(tokens_7d, message.tokens)?;
+        if message.updated_ms >= now.saturating_sub(FIVE_HOURS_MS) {
+            tokens_5h = bounded_add(tokens_5h, message.tokens)?;
+        }
+        if message.updated_ms >= now.saturating_sub(ONE_HOUR_MS) {
+            tokens_1h = bounded_add(tokens_1h, message.tokens)?;
+        }
+        if latest
+            .as_ref()
+            .is_none_or(|current: &OpenCodeMessage| message.updated_ms > current.updated_ms)
+        {
+            latest = Some(message);
+        }
+    }
+    drop(rows);
+    drop(statement);
+
+    Some((tokens_5h, tokens_7d, tokens_1h, latest))
+}
+
+fn parse_opencode_scalars(
+    time_created: i64,
+    time_updated: i64,
+    role: Option<&str>,
+    model_id: Option<&str>,
+    provider_id: Option<&str>,
+    token_values: &[SqlValue; 4],
+) -> Option<OpenCodeMessage> {
+    if role != Some("assistant") {
+        return None;
+    }
+    if token_values
+        .iter()
+        .all(|value| matches!(value, SqlValue::Null))
+    {
+        return None;
+    }
+    let model_id = bounded(model_id, 48)?;
+    let provider_id = bounded(provider_id, 24);
+    let total = token_values
+        .iter()
+        .map(sql_aggregate_tokens)
+        .try_fold(0u64, |total, value| bounded_add(total, value?))?;
+    let updated_ms = u64::try_from(time_updated.max(time_created)).ok()?;
+    let model_label = provider_id
+        .as_ref()
+        .map(|provider| format!("{model_id} ({provider})"))
+        .unwrap_or(model_id);
+    let model = bounded(Some(&model_label), 80);
+    Some(OpenCodeMessage {
+        updated_ms,
+        tokens: total,
+        model,
+    })
+}
+
+fn bounded_add(total: u64, value: u64) -> Option<u64> {
+    total
+        .checked_add(value)
+        .filter(|sum| *sum <= MAX_AGGREGATE_TOKENS)
+}
+
+fn sql_aggregate_tokens(value: &SqlValue) -> Option<u64> {
+    match value {
+        SqlValue::Null => Some(0),
+        SqlValue::Integer(value) => u64::try_from(*value)
+            .ok()
+            .filter(|value| *value <= MAX_AGGREGATE_TOKENS),
+        SqlValue::Real(value) => aggregate_number(*value),
+        SqlValue::Text(value) => value.parse::<f64>().ok().and_then(aggregate_number),
+        SqlValue::Blob(_) => None,
+    }
+}
+
+fn aggregate_number(value: f64) -> Option<u64> {
+    if !value.is_finite() || !(0.0..=MAX_AGGREGATE_TOKENS as f64).contains(&value) {
+        return None;
+    }
+    Some(value.floor() as u64)
+}
+
+fn stale_by_age(last_updated_ms: Option<u64>) -> bool {
+    last_updated_ms
+        .and_then(|updated| now_ms().checked_sub(updated))
+        .is_none_or(|age| age > FRESH_FOR.as_millis() as u64)
 }
 
 fn apply_codex_windows(value: &Value, provider: &mut ProviderUsage) {
@@ -263,6 +616,334 @@ fn now_ms() -> u64 {
 mod tests {
     use super::*;
 
+    fn collector_with_sources(root: &Path) -> UsageCollector {
+        UsageCollector {
+            legacy_cache_dir: root.join("legacy"),
+            state_usage_dir: root.join("state"),
+            opencode_db: root.join("opencode.db"),
+        }
+    }
+
+    #[test]
+    fn collector_reads_current_omarchy_agent_records() {
+        let temp = tempfile::tempdir().unwrap();
+        let collector = collector_with_sources(temp.path());
+        fs::create_dir_all(&collector.state_usage_dir).unwrap();
+        fs::write(
+            collector.state_usage_dir.join("claude.json"),
+            r#"{
+                "schemaVersion":1,
+                "id":"claude",
+                "ready":true,
+                "tierLabel":"Max 20x",
+                "usageStatusText":"",
+                "limits":[
+                    {"label":"Session (5-hour)","percent":0.08,"resetsAt":"2027-01-15T12:30:00Z"},
+                    {"label":"Weekly (7-day)","percent":0.42,"resetsAt":"2027-01-20T00:00:00+00:00"},
+                    {"label":"Fable Weekly","percent":0.12,"resetsAt":"2027-01-20T00:00:00Z"}
+                ],
+                "todayTotalTokens":11619849
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            collector.state_usage_dir.join("codex.json"),
+            r#"{
+                "schemaVersion":1,
+                "id":"codex",
+                "ready":true,
+                "tierLabel":"pro",
+                "usageStatusText":"",
+                "limits":[{"label":"Weekly (7-day)","percent":0.51,"resetsAt":"2027-01-20T00:00:00Z"}],
+                "todayTotalTokens":564291335
+            }"#,
+        )
+        .unwrap();
+
+        let snapshot = collector.sample();
+        let claude = &snapshot.providers[0];
+        assert!(claude.available);
+        assert_eq!(claude.source, "omarchy");
+        assert_eq!(claude.plan.as_deref(), Some("Max 20x"));
+        assert_eq!(claude.primary.as_ref().unwrap().utilization, 0.08);
+        assert_eq!(claude.secondary.as_ref().unwrap().utilization, 0.42);
+        assert_eq!(claude.today_tokens, Some(11_619_849));
+        assert!(claude.primary.as_ref().unwrap().reset_at_ms.is_some());
+        let codex = &snapshot.providers[1];
+        assert!(codex.available);
+        assert_eq!(codex.primary.as_ref().unwrap().label, "Weekly (7-day)");
+        assert_eq!(codex.today_tokens, Some(564_291_335));
+    }
+
+    #[test]
+    fn unready_or_mismatched_omarchy_records_fail_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        let collector = collector_with_sources(temp.path());
+        fs::create_dir_all(&collector.state_usage_dir).unwrap();
+        fs::create_dir_all(&collector.legacy_cache_dir).unwrap();
+        fs::write(
+            collector.state_usage_dir.join("claude.json"),
+            r#"{"schemaVersion":1,"id":"other","ready":true,"usageStatusText":"","limits":[{"label":"5h","percent":0.1}]}"#,
+        )
+        .unwrap();
+        fs::write(
+            collector.legacy_cache_dir.join("claude-usage.json"),
+            r#"{"5h-utilization":0.25,"_source":"oauth","status":"allowed"}"#,
+        )
+        .unwrap();
+        fs::write(
+            collector.state_usage_dir.join("codex.json"),
+            r#"{"schemaVersion":1,"id":"codex","ready":true,"usageStatusText":"Codex unavailable","limits":[{"label":"Weekly","percent":0.5}]}"#,
+        )
+        .unwrap();
+
+        let snapshot = collector.sample();
+        assert!(!snapshot.providers[0].available);
+        assert!(snapshot.providers[0].primary.is_none());
+        assert!(!snapshot.providers[1].available);
+        assert!(snapshot.providers[1].primary.is_none());
+    }
+
+    #[test]
+    fn collector_recovers_opencode_local_budget_from_read_only_database() {
+        let temp = tempfile::tempdir().unwrap();
+        let collector = collector_with_sources(temp.path());
+        fs::create_dir_all(&collector.legacy_cache_dir).unwrap();
+        fs::write(
+            collector.legacy_cache_dir.join("opencode-usage.json"),
+            r#"{"5h-utilization":0.9,"_source":"stale","status":"allowed"}"#,
+        )
+        .unwrap();
+        let connection = Connection::open(&collector.opencode_db).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE message (\
+                    id TEXT PRIMARY KEY,\
+                    session_id TEXT NOT NULL,\
+                    time_created INTEGER NOT NULL,\
+                    time_updated INTEGER NOT NULL,\
+                    data TEXT NOT NULL\
+                );",
+            )
+            .unwrap();
+        let recent = now_ms().saturating_sub(30 * 60 * 1_000);
+        let older = now_ms().saturating_sub(6 * 60 * 60 * 1_000);
+        let future = now_ms().saturating_add(60 * 60 * 1_000);
+        connection
+            .execute(
+                "INSERT INTO message VALUES (?1, 'session-a', ?2, ?2, ?3)",
+                rusqlite::params![
+                    "recent",
+                    recent as i64,
+                    r#"{"role":"assistant","modelID":"gpt-test","providerID":"openai","tokens":{"input":100,"output":25,"reasoning":5,"cache":{"write":10,"read":900}}}"#
+                ],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO message VALUES (?1, 'session-b', ?2, ?2, ?3)",
+                rusqlite::params![
+                    "older",
+                    older as i64,
+                    r#"{"role":"assistant","modelID":"older","providerID":"local","tokens":{"input":200,"output":20}}"#
+                ],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO message VALUES (?1, 'session-c', ?2, ?2, ?3)",
+                rusqlite::params![
+                    "future",
+                    future as i64,
+                    r#"{"role":"assistant","modelID":"future","providerID":"untrusted","tokens":{"input":900000}}"#
+                ],
+            )
+            .unwrap();
+        let oversized_prompt = format!(
+            r#"{{"role":"user","prompt":"{}"}}"#,
+            "x".repeat(MAX_CACHE_BYTES as usize * 16)
+        );
+        connection
+            .execute(
+                "INSERT INTO message VALUES (?1, 'session-d', ?2, ?2, ?3)",
+                rusqlite::params!["oversized-user", recent as i64, oversized_prompt],
+            )
+            .unwrap();
+        drop(connection);
+
+        let opencode = collector.sample().providers.remove(2);
+        assert!(opencode.available);
+        assert_eq!(opencode.source, "sqlite");
+        assert_eq!(opencode.plan.as_deref(), Some("local messages"));
+        assert_eq!(opencode.model.as_deref(), Some("gpt-test (openai)"));
+        // Cache reads reuse prior context and are deliberately excluded from
+        // the established 1M/20M local soft-budget signal.
+        assert_eq!(opencode.primary.as_ref().unwrap().utilization, 0.00014);
+        assert_eq!(opencode.secondary.as_ref().unwrap().utilization, 0.000018);
+        assert_eq!(opencode.tokens_per_hour, Some(140));
+    }
+
+    #[test]
+    fn future_only_opencode_database_is_unavailable() {
+        let temp = tempfile::tempdir().unwrap();
+        let collector = collector_with_sources(temp.path());
+        let connection = Connection::open(&collector.opencode_db).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE message (\
+                    id TEXT PRIMARY KEY,\
+                    session_id TEXT NOT NULL,\
+                    time_created INTEGER NOT NULL,\
+                    time_updated INTEGER NOT NULL,\
+                    data TEXT NOT NULL\
+                );",
+            )
+            .unwrap();
+        let future = now_ms().saturating_add(60 * 60 * 1_000);
+        connection
+            .execute(
+                "INSERT INTO message VALUES ('future', 'session', ?1, ?1, ?2)",
+                rusqlite::params![
+                    future as i64,
+                    r#"{"role":"assistant","modelID":"future","providerID":"untrusted","tokens":{"input":900000}}"#
+                ],
+            )
+            .unwrap();
+        drop(connection);
+
+        let opencode = collector.sample().providers.remove(2);
+        assert!(!opencode.available);
+        assert!(opencode.primary.is_none());
+        assert!(opencode.model.is_none());
+    }
+
+    #[test]
+    fn omarchy_status_must_be_a_present_empty_string() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("claude.json");
+        for record in [
+            r#"{"schemaVersion":1,"id":"claude","ready":true,"limits":[{"label":"5h","percent":0.1}]}"#,
+            r#"{"schemaVersion":1,"id":"claude","ready":true,"usageStatusText":42,"limits":[{"label":"5h","percent":0.1}]}"#,
+            r#"{"schemaVersion":1,"id":"claude","ready":true,"usageStatusText":{},"limits":[{"label":"5h","percent":0.1}]}"#,
+        ] {
+            fs::write(&path, record).unwrap();
+            let provider = read_omarchy_provider(&path, "claude", "Claude");
+            assert!(!provider.available);
+            assert!(provider.primary.is_none());
+        }
+    }
+
+    #[test]
+    fn opencode_database_fails_closed_when_the_row_budget_is_exceeded() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = temp.path().join("opencode.db");
+        let connection = Connection::open(&database).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE message (\
+                    id TEXT PRIMARY KEY,\
+                    session_id TEXT NOT NULL,\
+                    time_created INTEGER NOT NULL,\
+                    time_updated INTEGER NOT NULL,\
+                    data TEXT NOT NULL\
+                );",
+            )
+            .unwrap();
+        let recent = now_ms().saturating_sub(1_000);
+        for index in 0..3 {
+            connection
+                .execute(
+                    "INSERT INTO message VALUES (?1, 'session', ?2, ?2, ?3)",
+                    rusqlite::params![
+                        format!("message-{index}"),
+                        recent as i64,
+                        r#"{"role":"assistant","modelID":"bounded","tokens":{"input":1}}"#
+                    ],
+                )
+                .unwrap();
+        }
+        drop(connection);
+
+        assert!(collect_opencode_usage_bounded(&database, 2, Duration::from_secs(1)).is_none());
+    }
+
+    #[test]
+    fn old_opencode_history_does_not_consume_the_recent_row_budget() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = temp.path().join("opencode.db");
+        let connection = Connection::open(&database).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE message (\
+                    id TEXT PRIMARY KEY,\
+                    session_id TEXT NOT NULL,\
+                    time_created INTEGER NOT NULL,\
+                    time_updated INTEGER NOT NULL,\
+                    data TEXT NOT NULL\
+                );",
+            )
+            .unwrap();
+        let old = now_ms().saturating_sub(SEVEN_DAYS_MS + 1_000);
+        let recent = now_ms().saturating_sub(1_000);
+        for index in 0..3 {
+            connection
+                .execute(
+                    "INSERT INTO message VALUES (?1, 'old-session', ?2, ?2, ?3)",
+                    rusqlite::params![
+                        format!("old-{index}"),
+                        old as i64,
+                        r#"{"role":"assistant","modelID":"old","tokens":{"input":1}}"#
+                    ],
+                )
+                .unwrap();
+        }
+        connection
+            .execute(
+                "INSERT INTO message VALUES ('recent', 'recent-session', ?1, ?1, ?2)",
+                rusqlite::params![
+                    recent as i64,
+                    r#"{"role":"assistant","modelID":"recent","tokens":{"input":7}}"#
+                ],
+            )
+            .unwrap();
+        drop(connection);
+
+        let aggregate =
+            collect_opencode_usage_bounded(&database, 2, Duration::from_secs(1)).unwrap();
+        assert_eq!((aggregate.0, aggregate.1, aggregate.2), (7, 7, 7));
+        assert_eq!(aggregate.3.unwrap().model.as_deref(), Some("recent"));
+    }
+
+    #[test]
+    fn empty_opencode_database_uses_a_valid_legacy_record() {
+        let temp = tempfile::tempdir().unwrap();
+        let collector = collector_with_sources(temp.path());
+        fs::create_dir_all(&collector.legacy_cache_dir).unwrap();
+        fs::write(
+            collector.legacy_cache_dir.join("opencode-usage.json"),
+            r#"{"5h-utilization":0.2,"_source":"sqlite","status":"allowed"}"#,
+        )
+        .unwrap();
+        let connection = Connection::open(&collector.opencode_db).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE message (\
+                    id TEXT PRIMARY KEY,\
+                    session_id TEXT NOT NULL,\
+                    time_created INTEGER NOT NULL,\
+                    time_updated INTEGER NOT NULL,\
+                    data TEXT NOT NULL\
+                );",
+            )
+            .unwrap();
+        drop(connection);
+
+        let opencode = collector.sample().providers.remove(2);
+        assert!(opencode.available);
+        assert_eq!(opencode.source, "sqlite");
+        assert_eq!(opencode.primary.as_ref().unwrap().utilization, 0.2);
+    }
+
     #[test]
     fn collector_normalizes_capacity_and_bounded_aggregate_activity() {
         let temp = tempfile::tempdir().unwrap();
@@ -282,7 +963,7 @@ mod tests {
         )
         .unwrap();
 
-        let snapshot = UsageCollector::new(temp.path()).sample();
+        let snapshot = UsageCollector::legacy_only(temp.path()).sample();
         assert_eq!(snapshot.providers.len(), 3);
         assert_eq!(
             snapshot.providers[0].primary.as_ref().unwrap().utilization,
@@ -305,7 +986,7 @@ mod tests {
     #[test]
     fn absent_files_remain_explicitly_unavailable() {
         let temp = tempfile::tempdir().unwrap();
-        let snapshot = UsageCollector::new(temp.path()).sample();
+        let snapshot = UsageCollector::legacy_only(temp.path()).sample();
         assert!(
             snapshot
                 .providers
@@ -329,7 +1010,7 @@ mod tests {
         )
         .unwrap();
 
-        let snapshot = UsageCollector::new(temp.path()).sample();
+        let snapshot = UsageCollector::legacy_only(temp.path()).sample();
         let claude = &snapshot.providers[0];
         assert_eq!(claude.status, "blocked");
         assert!(!claude.available);
@@ -358,7 +1039,7 @@ mod tests {
         )
         .unwrap();
 
-        let snapshot = UsageCollector::new(temp.path()).sample();
+        let snapshot = UsageCollector::legacy_only(temp.path()).sample();
         let claude = &snapshot.providers[0];
         assert!(claude.available);
         assert_eq!(claude.today_tokens, None);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,14 @@ Light desktop palettes are mapped to a dark-adaptive command surface and small
 semantic text roles are normalized to at least 4.5:1 contrast against their
 surface; primary text targets 7:1.
 
+The user-owned portal preferences persist only allowlisted Omarchy role names
+for nine XENEON meanings: Ready, Success, Working, Needs Help, Review Ready,
+Error, Unknown, Recording, and Processing. A presentation-only mapped-theme object
+resolves those names against the current live palette, so switching the
+Omarchy theme preserves the mapping intent while replacing every source hue.
+Invalid or missing selections fail closed to the reviewed defaults. The editor
+cannot store arbitrary colors or alter background, surface, or text roles.
+
 ```text
 Herdr public sockets     /proc, /sys, Hyprland
 AI usage records/DB        Voxtype, microd

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,9 +9,21 @@ narrow action policy. It also owns the optional Voxtype start/stop/cancel
 boundary and a private per-daemon dictation marker.
 Quickshell owns rendering and touch gesture state only.
 
+The portal's project-owned theme reader consumes only Omarchy's current
+presentation palette under `$XDG_STATE_HOME/omarchy/current`. Omarchy replaces
+the theme directory atomically, so QML watches the stable `theme.name` beacon
+and then reopens `theme/colors.toml`. Parsing is allowlisted and fail-soft:
+invalid or absent colors use bundled presentation defaults. Working, blocked,
+review, and error meaning maps respectively to the active theme's blue,
+yellow, green, and red roles. Theme selection never changes daemon state,
+Herdr actions, output identity, or touch mapping.
+Light desktop palettes are mapped to a dark-adaptive command surface and small
+semantic text roles are normalized to at least 4.5:1 contrast against their
+surface; primary text targets 7:1.
+
 ```text
 Herdr public sockets     /proc, /sys, Hyprland
-AI usage caches            Voxtype, microd
+AI usage records/DB        Voxtype, microd
           \                    /
                  xeneon-agentd
                        |
@@ -37,6 +49,12 @@ and live terminal identity. The current pane ID remains private action-routing
 state. Restarting the daemon invalidates every ID. Herdr disconnects immediately
 remove action targets and guarded capabilities.
 
+The adapter reads Herdr's durable `grouped`/`priority` agent-order mode on each
+normal reconciliation. The portal can request only those two typed values;
+the daemon applies them through `agent.order.set` and reorders the normalized
+cards from the returned authoritative state. An older Herdr without that API
+keeps agent telemetry working but exposes ordering as unavailable.
+
 Card names use Herdr's tab identity rather than terminal or prompt text. The
 daemon joins an agent's `tab_id` to the snapshot's tab label, with only
 `display_agent`, agent `name`, and canonical agent fallbacks.
@@ -51,11 +69,15 @@ Agent topology or state reconciliation does advance it.
 
 AI capacity and Micro refreshes do not advance the action sequence or count as
 portal interaction, so they cannot invalidate a guarded action or wake the
-ambient surface. Usage collection reads only the bounded normalized cache
-contracts already produced by the Omarchy Quickshell AI module. The daemon
-allowlists provider IDs, sources, status values, and safe metadata, clamps
-utilization and aggregate token activity, rejects oversized files, and never
-forwards credentials, prompts, per-model history, or raw provider payloads.
+ambient surface. Usage collection prefers the bounded schema-v1 Claude/Codex
+records produced by Omarchy, retains the former cache contract for transition
+compatibility, and reads only bounded aggregate input, output, reasoning, and
+cache-write counters from OpenCode's local
+SQLite message ledger to derive its soft-budget windows. The daemon allowlists
+provider IDs, record versions, status values, and safe metadata, clamps
+utilization and aggregate token activity, rejects oversized files and scans,
+and never forwards credentials, prompts, message contents, per-model history,
+or raw provider payloads.
 
 Micro collection uses one fixed read-only `device.status` request on the
 user-private local microd socket. Connected state requires a valid device

--- a/docs/concept-motion.md
+++ b/docs/concept-motion.md
@@ -32,7 +32,9 @@ the source.
 - Narrow uppercase monospaced display type with generous tracking.
 - Bright ice/cyan system copy and low-contrast blue-gray metadata.
 - Agent color retains the reviewed Codex Micro semantic meaning while taking
-  its blue/yellow/green/error hues from the active Omarchy palette. Capsule
+  its default blue/yellow/green/error hues from the active Omarchy palette.
+  The Palette pane can remap each XENEON meaning to another current-theme
+  swatch without changing the authoritative state. Capsule
   strokes, quiet glow layers, and their trail segments share the same state
   accent.
 - The strong halo is an on-canvas tapered after-image. Overlapping segments
@@ -44,10 +46,10 @@ the source.
   evenly spaced nodes.
 - The perimeter light is one GPU-blurred status bloom with two opposing
   clockwise runners, short soft glints, and six bounded trailing motes per
-  runner. It represents active agent execution only: working is blue, blocked
-  is amber, and the halo disappears when every agent is idle or no agent is
-  present. Voice and review-ready state remain explicit in the center/header
-  treatments instead of creating unrelated edge motion.
+  runner. It represents active agent execution only: working and blocked use
+  their configured semantic roles, and the halo disappears when every agent
+  is idle or no agent is present. Voice and review-ready state remain explicit
+  in the center/header treatments instead of creating unrelated edge motion.
 - Voice can override the center and ambient treatment through the existing
   bounded `idle`, `recording`, `processing`, `error`, and `unavailable`
   protocol states. QML does not infer audio level or transcript content.

--- a/docs/concept-motion.md
+++ b/docs/concept-motion.md
@@ -15,9 +15,9 @@
 | 0.00-2.25 s | Stable compact header, 3x2 cards, and slim telemetry strip | Keep the operational portal and real Herdr data path unchanged |
 | 2.25-2.75 s | Dashboard globally dims while the first center reticle appears | Use an opaque staged crossfade, not a card-to-node identity morph |
 | 2.75-3.75 s | Concentric radar rings expand outward with a smooth ease-out | Reveal structural rings from the center on entry |
-| 3.75-4.25 s | Center label and six neutral capsules fade and scale in, then colorize | Stage center before nodes and derive node color from normalized state |
+| 3.75-4.25 s | Center label and up to fourteen neutral capsules fade and scale in, then colorize | Stage center before nodes and derive node color from normalized state |
 | 4.25-7.25 s | Quiet ambient hold with subtle drift and breathing | Preserve a glanceable low-power hierarchy before stronger motion |
-| 7.25-10.08 s | Upright capsules orbit clockwise on nearby radii while soft, tapered colored after-images intensify | Move nodes independently and render one bounded segmented comet tail per state-colored node |
+| 7.25-10.08 s | Upright capsules orbit clockwise while soft, tapered colored after-images intensify | Preserve the original independent speeds, angles, and radii exactly through six agents, then extend that advancing-and-crossing multi-lane character with smaller capsules and fourteen bounded radii through fourteen agents |
 
 The source ends in ambient mode and does not show the reverse transition. The
 implemented ambient-to-control-center path deliberately mirrors its visual
@@ -31,12 +31,17 @@ the source.
 - Near-black navy canvas with dim slate/cyan structural geometry.
 - Narrow uppercase monospaced display type with generous tracking.
 - Bright ice/cyan system copy and low-contrast blue-gray metadata.
-- Agent color remains the reviewed Codex Micro semantic palette. Capsule
+- Agent color retains the reviewed Codex Micro semantic meaning while taking
+  its blue/yellow/green/error hues from the active Omarchy palette. Capsule
   strokes, quiet glow layers, and their trail segments share the same state
   accent.
 - The strong halo is an on-canvas tapered after-image. Overlapping segments
   share one path, fall off quadratically, and leave a small gap behind the
   capsule so the tail reads as motion instead of parallel orbit rails.
+- The dense seven-to-fourteen-agent composition keeps every capsule and halo
+  inside the constellation while independent integer-rate lanes intentionally
+  advance, cross, and sometimes overlap. Reduced motion alone uses static,
+  evenly spaced nodes.
 - The perimeter light is one GPU-blurred status bloom with two opposing
   clockwise runners, short soft glints, and six bounded trailing motes per
   runner. It represents active agent execution only: working is blue, blocked

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -18,6 +18,7 @@ versions must be rejected.
   "connection": "connected",
   "sessions": [],
   "agents": [],
+  "agent_order": {"available": true, "mode": "grouped"},
   "voice": {"state": "unavailable", "owned": false},
   "usage": {
     "providers": [
@@ -53,6 +54,9 @@ Terminal titles and prompt-derived content are never display-name sources.
 Optional `repository` and `worktree` values are sanitized checkout identity,
 not terminal content. `launch_pending` means Herdr has observed a launch request
 without yet observing a live agent; it is not treated as an agent state.
+`state_change_seq` is Herdr's monotonic state-change ordering scalar. Priority
+mode uses it descending within the same attention bucket so the EDGE and Herdr
+panels retain the same tie ordering; grouped mode continues to use Space order.
 
 Voice state is exactly `idle`, `recording`, `processing`, `error`, or
 `unavailable`. `owned` says only whether this daemon instance owns the private
@@ -63,20 +67,23 @@ or voice errors from stderr.
 activity. Utilization is a fraction from 0 through 1; reset timestamps, plan,
 model, `today_tokens`, and `tokens_per_hour` are optional bounded metadata.
 The aggregate token fields are provider-wide local activity totals, not
-per-request records. Usage never includes credentials, prompts, per-model
-history, cache file contents, or provider response bodies. `micro` is a
+per-request records. Usage never includes credentials, prompts, message
+contents, per-model history, cache/database contents, or provider response
+bodies. `micro` is a
 read-only normalized view of the local Codex Micro connection and optional
 device status. It never exposes the Micro socket protocol to QML.
 
 These additive v1 fields are optional for compatibility with older recorded
 fixtures. Clients default voice to unavailable, review-ready and launch-pending
 to false (except a legacy raw `done` agent), usage to an empty provider list,
-and Micro to disconnected.
+Micro to disconnected, and ordering to unavailable. When ordering is available,
+`grouped` preserves Herdr Space order and `priority` promotes attention states.
 Connection and action failures are separate fields, not invented agent states.
 Unavailable health metrics use `available: false` and omit `value`; they are
 never encoded as a false zero.
 
-The Herdr adapter accepts protocol 19 from Herdr v0.8.0. A different value from `ping` produces
+The Herdr adapter accepts protocol 20 from the Omarchy Herdr v0.8.0.r13 base.
+A different value from `ping` produces
 an `incompatible` session with no agents, targets, actions, snapshot request,
 or event subscription; the daemon does not guess compatibility across a Herdr
 protocol boundary.
@@ -132,6 +139,10 @@ The only actions are:
   none exists.
 - `claude_desktop`: takes no agent or capability and applies the same
   focus-or-launch policy to the fixed Claude Desktop identity.
+- `order_grouped` and `order_priority`: take no agent or capability and apply
+  one typed, idempotent ordering value through Herdr's public API. The daemon
+  polls the same authoritative Herdr setting, so changes made in either UI
+  converge without a portal-owned preference.
 
 There is no method, key, text, shell-command, prompt, close, or server-control
 passthrough. Desktop actions do not accept a desktop ID, executable, title,

--- a/quickshell/PortalPanel.qml
+++ b/quickshell/PortalPanel.qml
@@ -12,6 +12,7 @@ PanelWindow {
     required property var activity
     required property var preferences
     required property var theme
+    required property var sourceTheme
     property bool reducedMotion: false
     property string hostName: "LOCAL"
     property bool recoveryVisible: true
@@ -99,6 +100,7 @@ PanelWindow {
         activity: root.activity
         preferences: root.preferences
         theme: root.theme
+        sourceTheme: root.sourceTheme
         reducedMotion: root.reducedMotion
         previewMode: false
         hostName: root.hostName

--- a/quickshell/PortalPanel.qml
+++ b/quickshell/PortalPanel.qml
@@ -11,6 +11,7 @@ PanelWindow {
     required property var bridge
     required property var activity
     required property var preferences
+    required property var theme
     property bool reducedMotion: false
     property string hostName: "LOCAL"
     property bool recoveryVisible: true
@@ -20,7 +21,7 @@ PanelWindow {
 
     screen: modelData
     visible: recoveryVisible
-    color: "#02050b"
+    color: root.theme.canvas
     surfaceFormat.opaque: true
     focusable: false
     mask: null
@@ -97,6 +98,7 @@ PanelWindow {
         bridge: root.bridge
         activity: root.activity
         preferences: root.preferences
+        theme: root.theme
         reducedMotion: root.reducedMotion
         previewMode: false
         hostName: root.hostName

--- a/quickshell/components/AgentCard.qml
+++ b/quickshell/components/AgentCard.qml
@@ -1,11 +1,13 @@
 import QtQuick
 import QtQuick.Effects
 import "PortalPalette.js" as Palette
+import "../state/ThemePalette.js" as ThemePalette
 
 Item {
     id: root
 
     property var agent: null
+    property var theme: ThemePalette.fallback
     property bool reducedMotion: false
     property double snapshotSequence: -1
     property bool actionsEnabled: true
@@ -24,11 +26,36 @@ Item {
     signal interacted()
 
     readonly property string agentState: Palette.effectiveAgentState(agent)
-    readonly property color accent: Palette.agentColor(agent)
-    readonly property color readableAccent:
-        agentState === "idle" || agentState === "unknown"
-            ? "#a9b7c7"
-            : accent
+    readonly property color accent: Palette.agentColor(agent, theme)
+    readonly property color cardBackground:
+        focusHandler.pressed || guardedFocusHandler.pressed
+            ? theme.surfacePressed
+            : theme.surface
+    readonly property color readableAccent: ThemePalette.ensureContrast(
+        String(accent),
+        String(cardBackground),
+        4.5
+    )
+    readonly property color readablePrimary: ThemePalette.ensureContrast(
+        String(theme.textPrimary),
+        String(cardBackground),
+        7
+    )
+    readonly property color readableMuted: ThemePalette.ensureContrast(
+        String(theme.textMuted),
+        String(cardBackground),
+        4.5
+    )
+    readonly property color statePillBackground: ThemePalette.mixColors(
+        String(theme.surface),
+        String(accent),
+        0.14
+    )
+    readonly property color readablePillAccent: ThemePalette.ensureContrast(
+        String(accent),
+        String(statePillBackground),
+        4.5
+    )
     readonly property bool hasApproveAction:
         capability("approve") !== null
     readonly property bool hasInterruptAction:
@@ -109,6 +136,13 @@ Item {
         return context.length > 0 ? context.join("  ·  ") : "LOCAL WORKSPACE"
     }
 
+    function spaceLine() {
+        if (agent === null)
+            return ""
+        var workspace = String(agent.workspace || "").trim()
+        return "SPACE // " + (workspace !== "" ? workspace : "LOCAL")
+    }
+
     function requestFocus() {
         if (!root.enabled || agent === null || !canAction("open"))
             return false
@@ -126,7 +160,8 @@ Item {
         : "Focus " + String(agent.display_name || "Agent") + " in Herdr"
     Accessible.description: agent === null
         ? ""
-        : processLine() + ". " + contextLine() + ". Tap to focus in Herdr."
+        : processLine() + ". " + spaceLine() + ". " + contextLine()
+            + ". Tap to focus in Herdr."
     Accessible.onPressAction: root.requestFocus()
 
     MouseArea {
@@ -144,9 +179,7 @@ Item {
     Rectangle {
         anchors.fill: parent
         radius: 18
-        color: focusHandler.pressed || guardedFocusHandler.pressed
-            ? "#0d1726"
-            : "#0a101d"
+        color: root.cardBackground
         border.width: root.agent !== null && root.agent.focused ? 2 : 1
         border.color: Qt.alpha(
             root.accent,
@@ -319,7 +352,7 @@ Item {
                     ? ""
                     : String(root.agent.display_name || "")
                 textFormat: Text.PlainText
-                color: "#f3fbff"
+                color: root.readablePrimary
                 elide: Text.ElideRight
                 font {
                     family: "monospace"
@@ -335,7 +368,7 @@ Item {
                 height: 28
                 radius: 14
                 anchors.verticalCenter: parent.verticalCenter
-                color: Qt.alpha(root.accent, 0.14)
+                color: root.statePillBackground
                 border.width: 1
                 border.color: Qt.alpha(root.accent, 0.62)
 
@@ -345,7 +378,7 @@ Item {
                     anchors.centerIn: parent
                     text: root.stateLabel(root.agentState)
                     textFormat: Text.PlainText
-                    color: root.readableAccent
+                    color: root.readablePillAccent
                     font {
                         family: "monospace"
                         pixelSize: 12
@@ -357,6 +390,8 @@ Item {
         }
 
         Text {
+            id: processText
+
             anchors {
                 left: parent.left
                 right: parent.right
@@ -376,6 +411,26 @@ Item {
         }
 
         Text {
+            objectName: "agentSpaceName"
+            anchors {
+                left: parent.left
+                right: parent.right
+                top: processText.bottom
+                topMargin: 6
+            }
+            text: root.spaceLine().toUpperCase()
+            textFormat: Text.PlainText
+            color: root.readableMuted
+            elide: Text.ElideRight
+            font {
+                family: "monospace"
+                pixelSize: 11
+                weight: Font.DemiBold
+                letterSpacing: 0.5
+            }
+        }
+
+        Text {
             anchors {
                 left: parent.left
                 right: parent.right
@@ -383,7 +438,7 @@ Item {
             }
             text: root.contextLine()
             textFormat: Text.PlainText
-            color: "#7894ae"
+            color: root.readableMuted
             elide: Text.ElideMiddle
             font {
                 family: "monospace"
@@ -428,7 +483,8 @@ Item {
             visible: root.hasApproveAction
             enabled: visible
             label: "HOLD APPROVE"
-            accent: "#6cf7b0"
+            accent: root.theme.green
+            theme: root.theme
             reducedMotion: root.reducedMotion
             targetAgentId: root.agent === null ? "" : String(root.agent.id)
             targetCapabilityId: root.capabilityId("approve")
@@ -447,7 +503,8 @@ Item {
             visible: root.hasInterruptAction
             enabled: visible
             label: "HOLD INTERRUPT"
-            accent: "#ff5d83"
+            accent: root.theme.red
+            theme: root.theme
             reducedMotion: root.reducedMotion
             targetAgentId: root.agent === null ? "" : String(root.agent.id)
             targetCapabilityId: root.capabilityId("interrupt")

--- a/quickshell/components/AgentCard.qml
+++ b/quickshell/components/AgentCard.qml
@@ -483,7 +483,7 @@ Item {
             visible: root.hasApproveAction
             enabled: visible
             label: "HOLD APPROVE"
-            accent: root.theme.green
+            accent: root.theme.reviewReady
             theme: root.theme
             reducedMotion: root.reducedMotion
             targetAgentId: root.agent === null ? "" : String(root.agent.id)
@@ -503,7 +503,7 @@ Item {
             visible: root.hasInterruptAction
             enabled: visible
             label: "HOLD INTERRUPT"
-            accent: root.theme.red
+            accent: root.theme.error
             theme: root.theme
             reducedMotion: root.reducedMotion
             targetAgentId: root.agent === null ? "" : String(root.agent.id)

--- a/quickshell/components/AiUsageDock.qml
+++ b/quickshell/components/AiUsageDock.qml
@@ -1,9 +1,11 @@
 import QtQuick
+import "../state/ThemePalette.js" as ThemePalette
 
 Item {
     id: root
 
     property var usage: ({"providers": []})
+    property var theme: ThemePalette.fallback
     property var agents: []
     property var sessions: []
     property bool reducedMotion: false
@@ -161,10 +163,18 @@ Item {
         if (state === "LIVE")
             return accent
         if (state === "WARNING" || state === "STALE")
-            return "#e8b56d"
+            return theme.yellow
         if (state === "NO DATA")
-            return "#647787"
-        return "#e08a68"
+            return theme.textMuted
+        return theme.orange
+    }
+
+    function readableColor(color) {
+        return ThemePalette.ensureContrast(
+            String(color),
+            String(theme.surface),
+            4.5
+        )
     }
 
     Timer {
@@ -177,8 +187,10 @@ Item {
 
     component UsageLine: Item {
         property var usageWindow: null
+        property string providerId: ""
+        property string windowRole: ""
         property bool providerAvailable: false
-        property color accent: "#6f8aa7"
+        property color accent: root.theme.accent
         property bool reducedMotion: false
 
         visible: usageWindow !== null
@@ -190,13 +202,16 @@ Item {
             spacing: 8
 
             Text {
-                width: 72
+                id: windowLabel
+
+                objectName: "usageLabel_" + providerId + "_" + windowRole
+                width: 128
                 anchors.verticalCenter: parent.verticalCenter
                 text: usageWindow === null
                     ? ""
                     : String(usageWindow.label || "USAGE").toUpperCase()
                 textFormat: Text.PlainText
-                color: "#8aa8bd"
+                color: root.theme.textSecondary
                 elide: Text.ElideRight
                 font {
                     family: "monospace"
@@ -207,11 +222,11 @@ Item {
             }
 
             Rectangle {
-                width: Math.max(60, parent.width - 72 - 42 - 122 - 24)
+                width: Math.max(60, parent.width - 128 - 42 - 112 - 24)
                 height: 6
                 anchors.verticalCenter: parent.verticalCenter
                 radius: 3
-                color: "#162333"
+                color: root.theme.surfaceRaised
 
                 Rectangle {
                     width: parent.width * (
@@ -239,7 +254,9 @@ Item {
                     ? root.percent(usageWindow) + "%"
                     : "—"
                 textFormat: Text.PlainText
-                color: providerAvailable ? accent : "#647787"
+                color: providerAvailable
+                    ? root.readableColor(accent)
+                    : root.theme.textMuted
                 horizontalAlignment: Text.AlignRight
                 font {
                     family: "monospace"
@@ -249,11 +266,11 @@ Item {
             }
 
             Text {
-                width: 122
+                width: 112
                 anchors.verticalCenter: parent.verticalCenter
                 text: root.resetLabel(usageWindow)
                 textFormat: Text.PlainText
-                color: "#617f99"
+                color: root.theme.textMuted
                 elide: Text.ElideRight
                 horizontalAlignment: Text.AlignRight
                 font {
@@ -273,9 +290,9 @@ Item {
             width: 286
             height: parent.height
             radius: 16
-            color: "#09131f"
+            color: root.theme.surface
             border.width: 1
-            border.color: "#244963"
+            border.color: root.theme.border
 
             Column {
                 anchors {
@@ -288,7 +305,7 @@ Item {
                 Text {
                     text: "HERDR FLEET"
                     textFormat: Text.PlainText
-                    color: "#dff9ff"
+                    color: root.theme.textPrimary
                     font {
                         family: "monospace"
                         pixelSize: 17
@@ -300,7 +317,7 @@ Item {
                 Text {
                     text: root.fleetSummary()
                     textFormat: Text.PlainText
-                    color: "#5f7f9c"
+                    color: root.theme.textMuted
                     font {
                         family: "monospace"
                         pixelSize: 10
@@ -311,7 +328,7 @@ Item {
                 Text {
                     text: root.focusedSummary()
                     textFormat: Text.PlainText
-                    color: "#47718d"
+                    color: root.theme.textSecondary
                     font {
                         family: "monospace"
                         pixelSize: 9
@@ -339,20 +356,20 @@ Item {
                 readonly property string activityLabel:
                     root.activitySummary(provider)
                 readonly property color accent: modelData === "claude"
-                    ? "#e89562"
+                    ? root.theme.orange
                     : modelData === "codex"
-                        ? "#63e6ba"
-                        : "#a998ff"
+                        ? root.theme.green
+                        : root.theme.magenta
 
                 objectName: "usageCard_" + modelData
                 width: (root.width - 286 - 42) / 3
                 height: parent.height
                 radius: 16
-                color: "#09131f"
+                color: root.theme.surface
                 border.width: 1
                 border.color: provider.available
                     ? Qt.alpha(accent, provider.stale ? 0.34 : 0.62)
-                    : "#263847"
+                    : root.theme.border
 
                 Row {
                     id: providerHeader
@@ -372,7 +389,7 @@ Item {
                         width: Math.min(132, implicitWidth)
                         text: String(parent.parent.provider.label || "").toUpperCase()
                         textFormat: Text.PlainText
-                        color: "#dceff7"
+                        color: root.theme.textPrimary
                         elide: Text.ElideRight
                         font {
                             family: "monospace"
@@ -390,7 +407,7 @@ Item {
                         anchors.verticalCenter: parent.verticalCenter
                         text: root.providerDetail(parent.parent.provider)
                         textFormat: Text.PlainText
-                        color: "#5f7f9c"
+                        color: root.theme.textMuted
                         elide: Text.ElideRight
                         font {
                             family: "monospace"
@@ -405,9 +422,11 @@ Item {
                         anchors.verticalCenter: parent.verticalCenter
                         text: parent.parent.statusLabel
                         textFormat: Text.PlainText
-                        color: root.statusColor(
-                            parent.parent.provider,
-                            parent.parent.accent
+                        color: root.readableColor(
+                            root.statusColor(
+                                parent.parent.provider,
+                                parent.parent.accent
+                            )
                         )
                         font {
                             family: "monospace"
@@ -431,6 +450,8 @@ Item {
 
                     UsageLine {
                         width: parent.width
+                        providerId: parent.parent.modelData
+                        windowRole: "primary"
                         usageWindow: parent.parent.primaryUsage
                         providerAvailable: parent.parent.provider.available
                         accent: parent.parent.accent
@@ -439,6 +460,8 @@ Item {
 
                     UsageLine {
                         width: parent.width
+                        providerId: parent.parent.modelData
+                        windowRole: "secondary"
                         usageWindow: parent.parent.secondaryUsage
                         providerAvailable: parent.parent.provider.available
                         accent: parent.parent.accent
@@ -463,7 +486,7 @@ Item {
                         width: parent.width * 0.58
                         text: parent.parent.activityLabel
                         textFormat: Text.PlainText
-                        color: "#7898ae"
+                        color: root.theme.textSecondary
                         elide: Text.ElideRight
                         font {
                             family: "monospace"
@@ -477,7 +500,7 @@ Item {
                         width: parent.width - parent.children[0].width - 10
                         text: root.updatedLabel(parent.parent.provider)
                         textFormat: Text.PlainText
-                        color: "#54728c"
+                        color: root.theme.textMuted
                         elide: Text.ElideRight
                         horizontalAlignment: Text.AlignRight
                         font {

--- a/quickshell/components/AiUsageDock.qml
+++ b/quickshell/components/AiUsageDock.qml
@@ -163,7 +163,7 @@ Item {
         if (state === "LIVE")
             return accent
         if (state === "WARNING" || state === "STALE")
-            return theme.yellow
+            return theme.needsHelp
         if (state === "NO DATA")
             return theme.textMuted
         return theme.orange
@@ -205,7 +205,7 @@ Item {
                 id: windowLabel
 
                 objectName: "usageLabel_" + providerId + "_" + windowRole
-                width: 128
+                width: Math.max(128, Math.ceil(implicitWidth) + 2)
                 anchors.verticalCenter: parent.verticalCenter
                 text: usageWindow === null
                     ? ""
@@ -222,7 +222,11 @@ Item {
             }
 
             Rectangle {
-                width: Math.max(60, parent.width - 128 - 42 - 112 - 24)
+                width: Math.max(
+                    60,
+                    parent.width - windowLabel.width - 42 - 112
+                        - parent.spacing * 3
+                )
                 height: 6
                 anchors.verticalCenter: parent.verticalCenter
                 radius: 3

--- a/quickshell/components/AmbientAgentNode.qml
+++ b/quickshell/components/AmbientAgentNode.qml
@@ -1,10 +1,12 @@
 import QtQuick
 import "PortalPalette.js" as Palette
+import "../state/ThemePalette.js" as ThemePalette
 
 Item {
     id: root
 
     required property var agent
+    property var theme: ThemePalette.fallback
     property real centerX: 0
     property real centerY: 0
     property real radiusX: 320
@@ -12,18 +14,19 @@ Item {
     property real angleDegrees: 0
     property real reveal: 0
     property bool reducedMotion: false
+    property bool dense: false
     property real glowPulse: 0.55
 
     readonly property string agentState:
         Palette.effectiveAgentState(agent)
-    readonly property color accent: Palette.agentColor(agent)
+    readonly property color accent: Palette.agentColor(agent, theme)
     readonly property real angleRadians: angleDegrees * Math.PI / 180
     readonly property bool pulsing: !reducedMotion
         && reveal > 0
         && (agentState === "working" || agentState === "blocked")
 
-    width: 216
-    height: 80
+    width: dense ? 168 : 216
+    height: dense ? 50 : 80
     x: centerX + Math.cos(angleRadians) * radiusX - width / 2
     y: centerY + Math.sin(angleRadians) * radiusY - height / 2
     opacity: reveal
@@ -51,7 +54,7 @@ Item {
     Rectangle {
         anchors {
             fill: parent
-            margins: -12
+            margins: root.dense ? -8 : -12
         }
         radius: height / 2
         color: "transparent"
@@ -63,7 +66,7 @@ Item {
     Rectangle {
         anchors {
             fill: parent
-            margins: -6
+            margins: root.dense ? -4 : -6
         }
         radius: height / 2
         color: Qt.alpha(root.accent, 0.04)
@@ -75,7 +78,7 @@ Item {
     Rectangle {
         anchors.fill: parent
         radius: height / 2
-        color: "#ed08111d"
+        color: Qt.alpha(root.theme.surfaceRaised, 0.93)
         border.width: 2
         border.color: root.accent
     }
@@ -83,12 +86,12 @@ Item {
     Rectangle {
         anchors {
             left: parent.left
-            leftMargin: 18
+            leftMargin: root.dense ? 12 : 18
             verticalCenter: parent.verticalCenter
         }
-        width: 10
-        height: 10
-        radius: 5
+        width: root.dense ? 8 : 10
+        height: width
+        radius: width / 2
         color: root.accent
         opacity: root.agentState === "idle" ? 0.62 : 1
     }
@@ -97,21 +100,21 @@ Item {
         objectName: "ambientAgentDisplayName"
         anchors {
             left: parent.left
-            leftMargin: 38
+            leftMargin: root.dense ? 27 : 38
             right: parent.right
-            rightMargin: 18
+            rightMargin: root.dense ? 10 : 18
             verticalCenter: parent.verticalCenter
         }
         text: String(root.agent.display_name || "AGENT").toUpperCase()
         textFormat: Text.PlainText
-        color: "#e7f8ff"
+        color: root.theme.textPrimary
         horizontalAlignment: Text.AlignHCenter
         elide: Text.ElideRight
         font {
             family: "monospace"
-            pixelSize: 16
+            pixelSize: root.dense ? 13 : 16
             weight: Font.DemiBold
-            letterSpacing: 0.8
+            letterSpacing: root.dense ? 0.5 : 0.8
         }
     }
 

--- a/quickshell/components/AmbientRing.qml
+++ b/quickshell/components/AmbientRing.qml
@@ -2,11 +2,13 @@ import QtQuick
 import QtQuick.Effects
 import QtQuick.Shapes
 import "PortalPalette.js" as Palette
+import "../state/ThemePalette.js" as ThemePalette
 
 Item {
     id: root
 
     property var agents: []
+    property var theme: ThemePalette.fallback
     property var voice: ({})
     property string connectionState: "reconnecting"
     property bool reducedMotion: false
@@ -14,7 +16,12 @@ Item {
     property real phase: 0
 
     readonly property string mode: Palette.perimeterMode(agents)
-    readonly property color accent: Palette.ambientColor(mode)
+    readonly property color accent: Palette.ambientColor(mode, theme)
+    readonly property color readableAccent: ThemePalette.ensureContrast(
+        String(accent),
+        String(theme.surface),
+        4.5
+    )
     readonly property bool active: mode !== "off" && !suppressRunners
     readonly property bool moving: active && !reducedMotion
     readonly property int runnerCount: 2
@@ -308,7 +315,7 @@ Item {
         )
 
         ShapePath {
-            strokeColor: "#e8fbff"
+            strokeColor: root.theme.textPrimary
             strokeWidth: runnerCore.strokeWidth
             fillColor: "transparent"
             capStyle: ShapePath.RoundCap
@@ -384,7 +391,7 @@ Item {
         width: haloText.implicitWidth + 30
         height: root.active ? 27 : 0
         radius: 14
-        color: "#e8070d18"
+        color: Qt.alpha(root.theme.surface, 0.9)
         border.width: height > 0 ? 1 : 0
         border.color: Qt.alpha(root.accent, 0.48)
         clip: true
@@ -396,7 +403,7 @@ Item {
             anchors.centerIn: parent
             text: Palette.ambientLabel(root.mode)
             textFormat: Text.PlainText
-            color: root.accent
+            color: root.readableAccent
             font {
                 family: "monospace"
                 pixelSize: 11

--- a/quickshell/components/AmbientView.qml
+++ b/quickshell/components/AmbientView.qml
@@ -1,10 +1,12 @@
 import QtQuick
 import "PortalPalette.js" as Palette
+import "../state/ThemePalette.js" as ThemePalette
 
 Item {
     id: root
 
     property bool active: false
+    property var theme: ThemePalette.fallback
     property bool reducedMotion: false
     property var agents: []
     property var health: ({})
@@ -20,7 +22,8 @@ Item {
 
     readonly property int entryDurationMs: 1350
     readonly property int exitDurationMs: 1000
-    readonly property int nodeLimit: 6
+    readonly property int nodeLimit: 14
+    readonly property bool denseConstellation: visibleAgentCount > 6
     readonly property int visibleAgentCount: Math.min(
         nodeLimit,
         agents.length
@@ -31,8 +34,13 @@ Item {
         connectionState
     )
     readonly property color modeAccent: mode === "off"
-        ? "#55e9ff"
-        : Palette.ambientColor(mode)
+        ? theme.muted
+        : Palette.ambientColor(mode, theme)
+    readonly property color readableModeAccent: ThemePalette.ensureContrast(
+        String(modeAccent),
+        String(theme.surface),
+        4.5
+    )
     readonly property bool orbiting: !reducedMotion
         && (active || exitShield || revealProgress > 0)
     readonly property real curtainProgress: stage(
@@ -202,15 +210,16 @@ Item {
 
     Rectangle {
         anchors.fill: parent
-        color: "#020711"
+        color: root.theme.canvas
         opacity: root.curtainProgress
     }
 
     Item {
         id: constellation
+        objectName: "ambientConstellation"
 
-        width: 1540
-        height: 560
+        width: 1900
+        height: 580
         anchors.centerIn: parent
 
         Repeater {
@@ -230,7 +239,7 @@ Item {
                 color: "transparent"
                 border.width: index === 4 ? 2 : 1
                 border.color: Qt.alpha(
-                    index % 2 === 0 ? root.modeAccent : "#7a65ff",
+                    index % 2 === 0 ? root.modeAccent : root.theme.magenta,
                     0.1 + (4 - index) * 0.025
                 )
                 opacity: root.ringProgress
@@ -250,7 +259,7 @@ Item {
                 radiusX: root.radiusXFor(index)
                 radiusY: root.radiusYFor(index)
                 angleDegrees: root.nodeAngleDegrees(index)
-                accent: Palette.agentColor(root.agents[index])
+                accent: Palette.agentColor(root.agents[index], root.theme)
                 reveal: root.reducedMotion
                     ? 0
                     : root.nodeProgress
@@ -268,6 +277,7 @@ Item {
 
                 objectName: "ambientAgentNode-" + index
                 agent: root.agents[index]
+                theme: root.theme
                 centerX: constellation.width / 2
                 centerY: constellation.height / 2
                 radiusX: root.radiusXFor(index)
@@ -275,6 +285,7 @@ Item {
                 angleDegrees: root.nodeAngleDegrees(index)
                 reveal: root.nodeProgress
                 reducedMotion: root.reducedMotion
+                dense: root.denseConstellation
             }
         }
 
@@ -301,7 +312,7 @@ Item {
             Rectangle {
                 anchors.fill: parent
                 radius: width / 2
-                color: "#d9060c16"
+                color: Qt.alpha(root.theme.surface, 0.85)
                 border.width: 2
                 border.color: Qt.alpha(root.modeAccent, 0.54)
             }
@@ -349,7 +360,7 @@ Item {
                     anchors.horizontalCenter: parent.horizontalCenter
                     text: root.centerTitle()
                     textFormat: Text.PlainText
-                    color: root.modeAccent
+                    color: root.readableModeAccent
                     font {
                         family: "monospace"
                         pixelSize: 34
@@ -362,7 +373,7 @@ Item {
                     anchors.horizontalCenter: parent.horizontalCenter
                     text: root.centerDetail()
                     textFormat: Text.PlainText
-                    color: "#7e9bb4"
+                    color: root.theme.textSecondary
                     font {
                         family: "monospace"
                         pixelSize: 13
@@ -382,7 +393,7 @@ Item {
         }
         text: "TOUCH TO WAKE"
         textFormat: Text.PlainText
-        color: "#7892ad"
+        color: root.theme.textMuted
         opacity: root.nodeProgress
         font {
             family: "monospace"
@@ -419,32 +430,47 @@ Item {
     }
 
     function speedFor(index) {
-        // Integer multipliers ensure every shared phase reset is an exact
-        // number of full turns, so no node or trail can jump at a loop.
-        return [1, 2, 1, 3, 2, 1][index % nodeLimit]
+        // Preserve the original independent-lane character at every count.
+        // Integer multipliers keep phase resets continuous while allowing
+        // agents to advance and cross instead of revolving as one rigid shape.
+        if (!denseConstellation)
+            return [1, 2, 1, 3, 2, 1][index % 6]
+        return [1, 2, 1, 3, 2, 1, 2, 3, 1, 2, 3, 1, 2, 3][index % 14]
     }
 
     function baseAngleFor(index) {
-        return [-88, -30, 30, 92, 154, 214][index % nodeLimit]
+        if (!denseConstellation && !reducedMotion)
+            return [-88, -30, 30, 92, 154, 214][index % 6]
+        var count = Math.max(1, visibleAgentCount)
+        var startAngle = count === 2 ? 0 : -90
+        return startAngle + index * 360 / count
     }
 
     function radiusXFor(index) {
         if (reducedMotion)
-            return 520
-        return [410, 530, 650, 470, 600, 510][index % nodeLimit]
+            return denseConstellation ? 820 : 520
+        if (!denseConstellation)
+            return [410, 530, 650, 470, 600, 510][index % 6]
+        return [
+            720, 800, 660, 780, 700, 820, 750,
+            680, 810, 730, 770, 650, 790, 710
+        ][index % 14]
     }
 
     function radiusYFor(index) {
         if (reducedMotion)
-            return 230
-        return [152, 205, 174, 238, 214, 188][index % nodeLimit]
+            return denseConstellation ? 242 : 230
+        if (!denseConstellation)
+            return [152, 205, 174, 238, 214, 188][index % 6]
+        return [
+            190, 230, 205, 242, 215, 185, 235,
+            200, 225, 195, 240, 210, 180, 220
+        ][index % 14]
     }
 
     function nodeAngleDegrees(index) {
         if (reducedMotion) {
-            var count = Math.max(1, visibleAgentCount)
-            var startAngle = count === 2 ? 0 : -90
-            return startAngle + index * 360 / count
+            return baseAngleFor(index)
         }
         return baseAngleFor(index)
             + orbitPhase * 360 * speedFor(index)

--- a/quickshell/components/AmbientView.qml
+++ b/quickshell/components/AmbientView.qml
@@ -34,7 +34,7 @@ Item {
         connectionState
     )
     readonly property color modeAccent: mode === "off"
-        ? theme.muted
+        ? theme.ready
         : Palette.ambientColor(mode, theme)
     readonly property color readableModeAccent: ThemePalette.ensureContrast(
         String(modeAccent),

--- a/quickshell/components/DesktopAppButton.qml
+++ b/quickshell/components/DesktopAppButton.qml
@@ -1,17 +1,19 @@
 import QtQuick
+import "../state/ThemePalette.js" as ThemePalette
 
 Rectangle {
     id: root
 
     property string label: ""
     property string detail: "OPEN / FOCUS"
-    property color accent: "#55e9ff"
+    property var theme: ThemePalette.fallback
+    property color accent: theme.accent
     property bool pending: false
     signal triggered()
     signal interacted()
 
     radius: 14
-    color: tapHandler.pressed ? "#14283a" : "#0b1523"
+    color: tapHandler.pressed ? theme.surfacePressed : theme.surfaceRaised
     border.width: 1
     border.color: Qt.alpha(accent, pending ? 0.35 : 0.62)
     opacity: enabled ? 1 : 0.42
@@ -38,7 +40,7 @@ Rectangle {
             anchors.horizontalCenter: parent.horizontalCenter
             text: root.label
             textFormat: Text.PlainText
-            color: "#ecfbff"
+            color: root.theme.textPrimary
             font {
                 family: "monospace"
                 pixelSize: 15
@@ -51,7 +53,11 @@ Rectangle {
             anchors.horizontalCenter: parent.horizontalCenter
             text: root.pending ? "OPENING" : root.detail
             textFormat: Text.PlainText
-            color: root.accent
+            color: ThemePalette.ensureContrast(
+                String(root.accent),
+                String(root.theme.surfaceRaised),
+                4.5
+            )
             font {
                 family: "monospace"
                 pixelSize: 9

--- a/quickshell/components/DisplaySettingButton.qml
+++ b/quickshell/components/DisplaySettingButton.qml
@@ -1,11 +1,13 @@
 import QtQuick
+import "../state/ThemePalette.js" as ThemePalette
 
 Rectangle {
     id: root
 
     property string label: ""
     property string stateLabel: ""
-    property color accent: "#55e9ff"
+    property var theme: ThemePalette.fallback
+    property color accent: theme.accent
     property bool checked: false
 
     signal toggled()
@@ -19,14 +21,14 @@ Rectangle {
 
     radius: 13
     color: settingTap.pressed
-        ? "#17283a"
+        ? theme.surfacePressed
         : checked
             ? Qt.alpha(accent, 0.12)
-            : "#0b1523"
+            : theme.surfaceRaised
     border.width: 1
     border.color: checked
         ? Qt.alpha(accent, 0.78)
-        : "#34506b"
+        : theme.border
 
     Accessible.role: Accessible.Button
     Accessible.ignored: !enabled
@@ -45,7 +47,7 @@ Rectangle {
             width: 9
             height: 9
             radius: width / 2
-            color: root.checked ? root.accent : "#526b82"
+            color: root.checked ? root.accent : root.theme.textMuted
 
             Rectangle {
                 anchors {
@@ -66,7 +68,7 @@ Rectangle {
             Text {
                 text: root.label
                 textFormat: Text.PlainText
-                color: "#e8f8fc"
+                color: root.theme.textPrimary
                 font {
                     family: "monospace"
                     pixelSize: 11
@@ -78,7 +80,13 @@ Rectangle {
             Text {
                 text: root.stateLabel
                 textFormat: Text.PlainText
-                color: root.checked ? root.accent : "#7892aa"
+                color: root.checked
+                    ? ThemePalette.ensureContrast(
+                        String(root.accent),
+                        String(root.theme.surfaceRaised),
+                        4.5
+                    )
+                    : root.theme.textMuted
                 font {
                     family: "monospace"
                     pixelSize: 8

--- a/quickshell/components/DisplaySettingsControls.qml
+++ b/quickshell/components/DisplaySettingsControls.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import "../state/ThemePalette.js" as ThemePalette
 
 Item {
     id: root
@@ -6,6 +7,7 @@ Item {
     property bool motionReduced: false
     property bool dimmed: false
     property bool motionForced: false
+    property var theme: ThemePalette.fallback
 
     signal motionToggleRequested()
     signal dimToggleRequested()
@@ -27,7 +29,8 @@ Item {
                 : root.motionReduced
                     ? "REDUCED"
                     : "FULL"
-            accent: "#55e9ff"
+            accent: root.theme.accent
+            theme: root.theme
             checked: root.motionReduced
             enabled: !root.motionForced
             onToggled: root.motionToggleRequested()
@@ -39,7 +42,8 @@ Item {
             height: parent.height
             label: "SCREEN"
             stateLabel: root.dimmed ? "MINIMUM" : "NORMAL"
-            accent: "#9a7cff"
+            accent: root.theme.magenta
+            theme: root.theme
             checked: root.dimmed
             onToggled: root.dimToggleRequested()
         }

--- a/quickshell/components/DisplaySettingsControls.qml
+++ b/quickshell/components/DisplaySettingsControls.qml
@@ -7,12 +7,15 @@ Item {
     property bool motionReduced: false
     property bool dimmed: false
     property bool motionForced: false
+    property bool paletteOpen: false
+    property bool paletteCustom: false
     property var theme: ThemePalette.fallback
 
     signal motionToggleRequested()
     signal dimToggleRequested()
+    signal paletteToggleRequested()
 
-    width: 200
+    width: 304
     height: 52
 
     Row {
@@ -46,6 +49,22 @@ Item {
             theme: root.theme
             checked: root.dimmed
             onToggled: root.dimToggleRequested()
+        }
+
+        DisplaySettingButton {
+            objectName: "paletteSettingButton"
+            width: 96
+            height: parent.height
+            label: "PALETTE"
+            stateLabel: root.paletteOpen
+                ? "OPEN"
+                : root.paletteCustom
+                    ? "CUSTOM"
+                    : "THEME"
+            accent: root.theme.accent
+            theme: root.theme
+            checked: root.paletteOpen || root.paletteCustom
+            onToggled: root.paletteToggleRequested()
         }
     }
 }

--- a/quickshell/components/HoldControl.qml
+++ b/quickshell/components/HoldControl.qml
@@ -1,10 +1,12 @@
 import QtQuick
+import "../state/ThemePalette.js" as ThemePalette
 
 Item {
     id: root
 
     property string label: "HOLD"
-    property color accent: "#66f7ff"
+    property var theme: ThemePalette.fallback
+    property color accent: theme.accent
     property bool reducedMotion: false
     property bool completed: false
     property bool armed: false
@@ -99,9 +101,13 @@ Item {
     Rectangle {
         anchors.fill: parent
         radius: 10
-        color: holdHandler.pressed ? Qt.alpha(root.accent, 0.18) : "#0b1422"
+        color: holdHandler.pressed
+            ? Qt.alpha(root.accent, 0.18)
+            : root.theme.surfaceRaised
         border.width: 1
-        border.color: root.enabled ? Qt.alpha(root.accent, 0.72) : "#263143"
+        border.color: root.enabled
+            ? Qt.alpha(root.accent, 0.72)
+            : root.theme.border
         opacity: root.enabled ? 1 : 0.36
     }
 
@@ -140,7 +146,9 @@ Item {
         anchors.centerIn: parent
         text: root.label
         textFormat: Text.PlainText
-        color: root.enabled ? "#edfaff" : "#718096"
+        color: root.enabled
+            ? root.theme.textPrimary
+            : root.theme.textMuted
         font {
             family: "monospace"
             pixelSize: 15

--- a/quickshell/components/MicroDrawer.qml
+++ b/quickshell/components/MicroDrawer.qml
@@ -13,8 +13,8 @@ Item {
     property var agents: []
     property var voice: ({"state": "unavailable", "owned": false})
     readonly property color connectionColor: micro.connected
-        ? theme.green
-        : theme.red
+        ? theme.success
+        : theme.error
     readonly property color readableConnectionColor: readableStateColor(
         connectionColor,
         theme.surface
@@ -52,19 +52,19 @@ Item {
     function ringColor() {
         switch (ringState()) {
         case "recording":
-            return root.theme.green
+            return root.theme.recording
         case "processing":
-            return root.theme.cyan
+            return root.theme.processing
         case "error":
-            return root.theme.red
+            return root.theme.error
         case "blocked":
-            return root.theme.yellow
+            return root.theme.needsHelp
         case "review":
-            return root.theme.green
+            return root.theme.reviewReady
         case "working":
-            return root.theme.blue
+            return root.theme.working
         default:
-            return root.theme.muted
+            return root.theme.ready
         }
     }
 
@@ -115,7 +115,7 @@ Item {
         border.width: 1
         border.color: root.micro.connected
             ? root.theme.borderStrong
-            : root.theme.red
+            : root.theme.error
 
         Column {
             anchors {

--- a/quickshell/components/MicroDrawer.qml
+++ b/quickshell/components/MicroDrawer.qml
@@ -1,15 +1,24 @@
 import QtQuick
 import "PortalPalette.js" as Palette
+import "../state/ThemePalette.js" as ThemePalette
 
 Item {
     id: root
 
     property bool opened: false
+    property var theme: ThemePalette.fallback
     property bool reducedMotion: false
     property bool interactive: true
     property var micro: ({"connected": false})
     property var agents: []
     property var voice: ({"state": "unavailable", "owned": false})
+    readonly property color connectionColor: micro.connected
+        ? theme.green
+        : theme.red
+    readonly property color readableConnectionColor: readableStateColor(
+        connectionColor,
+        theme.surface
+    )
 
     signal closeRequested()
     signal interacted()
@@ -43,20 +52,28 @@ Item {
     function ringColor() {
         switch (ringState()) {
         case "recording":
-            return "#49e0cf"
+            return root.theme.green
         case "processing":
-            return "#eefcff"
+            return root.theme.cyan
         case "error":
-            return "#ff435f"
+            return root.theme.red
         case "blocked":
-            return "#ffad3d"
+            return root.theme.yellow
         case "review":
-            return "#5df09a"
+            return root.theme.green
         case "working":
-            return "#4d9dff"
+            return root.theme.blue
         default:
-            return "#30465b"
+            return root.theme.muted
         }
+    }
+
+    function readableStateColor(color, background) {
+        return ThemePalette.ensureContrast(
+            String(color),
+            String(background),
+            4.5
+        )
     }
 
     visible: opened
@@ -69,7 +86,7 @@ Item {
             top: parent.top
             bottom: parent.bottom
         }
-        color: "#9c02050b"
+        color: Qt.alpha(root.theme.canvas, 0.62)
 
         TapHandler {
             enabled: root.enabled
@@ -94,9 +111,11 @@ Item {
         }
         width: 720
         radius: 22
-        color: "#f20a111d"
+        color: Qt.alpha(root.theme.surface, 0.95)
         border.width: 1
-        border.color: root.micro.connected ? "#3d7891" : "#5c3543"
+        border.color: root.micro.connected
+            ? root.theme.borderStrong
+            : root.theme.red
 
         Column {
             anchors {
@@ -112,7 +131,7 @@ Item {
             Text {
                 text: "CODEX MICRO // VIRTUAL PROJECTION"
                 textFormat: Text.PlainText
-                color: "#ecfbff"
+                color: root.theme.textPrimary
                 font {
                     family: "monospace"
                     pixelSize: 20
@@ -126,7 +145,7 @@ Item {
                     ? "DEVICE LINK ACTIVE · READ ONLY"
                     : "DEVICE LINK UNAVAILABLE"
                 textFormat: Text.PlainText
-                color: root.micro.connected ? "#62e5c2" : "#ff6d86"
+                color: root.readableConnectionColor
                 font {
                     family: "monospace"
                     pixelSize: 11
@@ -148,9 +167,11 @@ Item {
             width: 66
             height: 42
             radius: 10
-            color: closeTap.pressed ? "#1b3043" : "#101d2c"
+            color: closeTap.pressed
+                ? root.theme.surfacePressed
+                : root.theme.surfaceRaised
             border.width: 1
-            border.color: "#35536c"
+            border.color: root.theme.border
 
             Accessible.role: Accessible.Button
             Accessible.ignored: !root.enabled
@@ -164,7 +185,7 @@ Item {
                 anchors.centerIn: parent
                 text: "CLOSE"
                 textFormat: Text.PlainText
-                color: "#9ec7df"
+                color: root.theme.textSecondary
                 font {
                     family: "monospace"
                     pixelSize: 11
@@ -206,7 +227,7 @@ Item {
                     height: 158
                     radius: 79
                     anchors.horizontalCenter: parent.horizontalCenter
-                    color: "#06101a"
+                    color: root.theme.surface
                     border.width: 10
                     border.color: root.ringColor()
 
@@ -243,7 +264,7 @@ Item {
                                     : "LINK"
                                 : "OFF"
                             textFormat: Text.PlainText
-                            color: "#f0fbff"
+                            color: root.theme.textPrimary
                             font {
                                 family: "monospace"
                                 pixelSize: 27
@@ -255,7 +276,10 @@ Item {
                             anchors.horizontalCenter: parent.horizontalCenter
                             text: root.ringState().toUpperCase()
                             textFormat: Text.PlainText
-                            color: root.ringColor()
+                            color: root.readableStateColor(
+                                root.ringColor(),
+                                root.theme.surface
+                            )
                             font {
                                 family: "monospace"
                                 pixelSize: 10
@@ -282,7 +306,7 @@ Item {
                             )
                         : "WAITING FOR MICROD"
                     textFormat: Text.PlainText
-                    color: "#718da5"
+                    color: root.theme.textMuted
                     horizontalAlignment: Text.AlignHCenter
                     wrapMode: Text.Wrap
                     font {
@@ -311,12 +335,19 @@ Item {
                                 ? root.agents[index]
                                 : null
                         readonly property color accent:
-                            agent === null ? "#293b4c" : Palette.agentColor(agent)
+                            agent === null
+                                ? root.theme.border
+                                : Palette.agentColor(agent, root.theme)
+                        readonly property color readableAccent:
+                            root.readableStateColor(
+                                accent,
+                                root.theme.surfaceRaised
+                            )
 
                         width: (slotGrid.width - slotGrid.columnSpacing) / 2
                         height: (slotGrid.height - slotGrid.rowSpacing * 2) / 3
                         radius: 15
-                        color: "#0b1724"
+                        color: root.theme.surfaceRaised
                         border.width: 1
                         border.color: Qt.alpha(accent, agent === null ? 0.45 : 0.78)
 
@@ -348,7 +379,9 @@ Item {
                                     ? "SLOT " + (index + 1)
                                     : String(agent.display_name || "Agent")
                                 textFormat: Text.PlainText
-                                color: agent === null ? "#526779" : "#e8f7fc"
+                                color: agent === null
+                                    ? root.theme.textMuted
+                                    : root.theme.textPrimary
                                 elide: Text.ElideRight
                                 font {
                                     family: "monospace"
@@ -365,7 +398,7 @@ Item {
                                         agent
                                     ).toUpperCase()
                                 textFormat: Text.PlainText
-                                color: parent.parent.accent
+                                color: parent.parent.readableAccent
                                 elide: Text.ElideRight
                                 font {
                                     family: "monospace"

--- a/quickshell/components/OrbitTrail.qml
+++ b/quickshell/components/OrbitTrail.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Shapes
+import "../state/ThemePalette.js" as ThemePalette
 
 Item {
     id: root
@@ -10,7 +11,7 @@ Item {
     property real radiusY: 170
     property real angleDegrees: 0
     property real reveal: 0
-    property color accent: "#55e9ff"
+    property color accent: ThemePalette.fallback.accent
     property real sweepDegrees: 44
 
     // One broad after-image is built from nested arcs that share the same head.

--- a/quickshell/components/PaletteSettingsPane.qml
+++ b/quickshell/components/PaletteSettingsPane.qml
@@ -1,0 +1,561 @@
+import QtQuick
+import "../state/ThemePalette.js" as ThemePalette
+
+Rectangle {
+    id: root
+
+    property bool open: false
+    property var preferences
+    property var sourceTheme: ThemePalette.fallback
+    property var theme: ThemePalette.fallback
+
+    signal closeRequested()
+    signal interactionOccurred()
+
+    readonly property var paletteRoles: ThemePalette.selectableRoles
+    readonly property var mappingTargets: [
+        {"id": "ready", "label": "READY", "fallback": "muted"},
+        {"id": "success", "label": "SUCCESS", "fallback": "green"},
+        {"id": "working", "label": "WORKING", "fallback": "blue"},
+        {"id": "needsHelp", "label": "NEEDS HELP", "fallback": "yellow"},
+        {
+            "id": "reviewReady",
+            "label": "REVIEW READY",
+            "fallback": "green"
+        },
+        {"id": "error", "label": "ERROR", "fallback": "red"},
+        {"id": "unknown", "label": "UNKNOWN", "fallback": "magenta"},
+        {"id": "recording", "label": "RECORDING", "fallback": "green"},
+        {"id": "processing", "label": "PROCESSING", "fallback": "cyan"}
+    ]
+
+    readonly property bool customized:
+        storedSelectionFor("ready", "muted") !== "muted"
+        || storedSelectionFor("success", "green") !== "green"
+        || storedSelectionFor("working", "blue") !== "blue"
+        || storedSelectionFor("needsHelp", "yellow") !== "yellow"
+        || storedSelectionFor("reviewReady", "green") !== "green"
+        || storedSelectionFor("error", "red") !== "red"
+        || storedSelectionFor("unknown", "magenta") !== "magenta"
+        || storedSelectionFor("recording", "green") !== "green"
+        || storedSelectionFor("processing", "cyan") !== "cyan"
+
+    function storedSelectionFor(target, fallbackRole) {
+        if (preferences === null || preferences === undefined)
+            return fallbackRole
+        var value = preferences[target + "ColorRole"]
+        if (value === undefined || value === null || String(value) === "")
+            return fallbackRole
+        return String(value).toLowerCase()
+    }
+
+    function selectionFor(target, fallbackRole) {
+        if (preferences === null || preferences === undefined)
+            return fallbackRole
+        switch (target) {
+        case "ready":
+            return ThemePalette.selectableRole(
+                preferences.readyColorRole, fallbackRole
+            )
+        case "success":
+            return ThemePalette.selectableRole(
+                preferences.successColorRole, fallbackRole
+            )
+        case "working":
+            return ThemePalette.selectableRole(
+                preferences.workingColorRole, fallbackRole
+            )
+        case "needsHelp":
+            return ThemePalette.selectableRole(
+                preferences.needsHelpColorRole, fallbackRole
+            )
+        case "reviewReady":
+            return ThemePalette.selectableRole(
+                preferences.reviewReadyColorRole, fallbackRole
+            )
+        case "error":
+            return ThemePalette.selectableRole(
+                preferences.errorColorRole, fallbackRole
+            )
+        case "unknown":
+            return ThemePalette.selectableRole(
+                preferences.unknownColorRole, fallbackRole
+            )
+        case "recording":
+            return ThemePalette.selectableRole(
+                preferences.recordingColorRole, fallbackRole
+            )
+        case "processing":
+            return ThemePalette.selectableRole(
+                preferences.processingColorRole, fallbackRole
+            )
+        default:
+            return fallbackRole
+        }
+    }
+
+    function setMapping(target, role) {
+        if (preferences === null || preferences === undefined
+                || ThemePalette.selectableRoles.indexOf(role) < 0)
+            return false
+        switch (target) {
+        case "ready":
+            preferences.readyColorRole = role
+            break
+        case "success":
+            preferences.successColorRole = role
+            break
+        case "working":
+            preferences.workingColorRole = role
+            break
+        case "needsHelp":
+            preferences.needsHelpColorRole = role
+            break
+        case "reviewReady":
+            preferences.reviewReadyColorRole = role
+            break
+        case "error":
+            preferences.errorColorRole = role
+            break
+        case "unknown":
+            preferences.unknownColorRole = role
+            break
+        case "recording":
+            preferences.recordingColorRole = role
+            break
+        case "processing":
+            preferences.processingColorRole = role
+            break
+        default:
+            return false
+        }
+        if (typeof preferences.sync === "function")
+            preferences.sync()
+        root.interactionOccurred()
+        return true
+    }
+
+    function resetMappings() {
+        if (preferences === null || preferences === undefined)
+            return false
+        preferences.readyColorRole = "muted"
+        preferences.successColorRole = "green"
+        preferences.workingColorRole = "blue"
+        preferences.needsHelpColorRole = "yellow"
+        preferences.reviewReadyColorRole = "green"
+        preferences.errorColorRole = "red"
+        preferences.unknownColorRole = "magenta"
+        preferences.recordingColorRole = "green"
+        preferences.processingColorRole = "cyan"
+        if (typeof preferences.sync === "function")
+            preferences.sync()
+        root.interactionOccurred()
+        return true
+    }
+
+    function sourceColor(role) {
+        return ThemePalette.roleColor(sourceTheme, role, "accent")
+    }
+
+    function visibleThemeName() {
+        if (sourceTheme !== null && sourceTheme !== undefined
+                && sourceTheme.themeName !== undefined) {
+            var name = String(sourceTheme.themeName || "").trim()
+            if (name !== "")
+                return name.toUpperCase()
+        }
+        return "CURRENT OMARCHY THEME"
+    }
+
+    objectName: "paletteSettingsPane"
+    width: 960
+    height: 610
+    radius: 20
+    visible: root.open
+    enabled: root.open
+    color: theme.surface
+    border.width: 2
+    border.color: theme.borderStrong
+    clip: true
+
+    Accessible.role: Accessible.Grouping
+    Accessible.ignored: !open
+    Accessible.name: "XENEON palette mapping"
+    Accessible.description:
+        "Assign current Omarchy theme colors to agent application states"
+
+    // Keep taps in blank pane space from reaching cards or ambient wake
+    // handling beneath this overlay. Later children remain the topmost hit
+    // targets for their own controls.
+    Item {
+        anchors.fill: parent
+
+        TapHandler {
+            gesturePolicy: TapHandler.ReleaseWithinBounds
+        }
+    }
+
+    Column {
+        anchors {
+            fill: parent
+            margins: 18
+        }
+        spacing: 8
+
+        Item {
+            width: parent.width
+            height: 44
+
+            Column {
+                anchors {
+                    left: parent.left
+                    verticalCenter: parent.verticalCenter
+                }
+                spacing: 1
+
+                Text {
+                    text: "PALETTE MAPPING"
+                    textFormat: Text.PlainText
+                    color: root.theme.textPrimary
+                    font {
+                        family: "monospace"
+                        pixelSize: 18
+                        weight: Font.Bold
+                        letterSpacing: 1
+                    }
+                }
+
+                Text {
+                    text: "THEME // " + root.visibleThemeName()
+                    textFormat: Text.PlainText
+                    color: root.theme.textMuted
+                    font {
+                        family: "monospace"
+                        pixelSize: 9
+                        letterSpacing: 0.5
+                    }
+                }
+            }
+
+            Rectangle {
+                id: closeButton
+                objectName: "paletteCloseButton"
+                anchors {
+                    right: parent.right
+                    verticalCenter: parent.verticalCenter
+                }
+                width: 48
+                height: 44
+                radius: 12
+                color: closeTap.pressed
+                    ? root.theme.surfacePressed
+                    : root.theme.surfaceRaised
+                border.width: 1
+                border.color: root.theme.border
+
+                function activate() {
+                    if (!enabled)
+                        return false
+                    root.closeRequested()
+                    return true
+                }
+
+                Accessible.role: Accessible.Button
+                Accessible.name: "Close palette mapping"
+                Accessible.onPressAction: activate()
+
+                Text {
+                    anchors.centerIn: parent
+                    text: "CLOSE"
+                    textFormat: Text.PlainText
+                    color: root.theme.textPrimary
+                    font {
+                        family: "monospace"
+                        pixelSize: 9
+                        weight: Font.Bold
+                    }
+                }
+
+                TapHandler {
+                    id: closeTap
+                    gesturePolicy: TapHandler.ReleaseWithinBounds
+                    onTapped: closeButton.activate()
+                }
+            }
+        }
+
+        Item {
+            width: parent.width
+            height: 64
+
+            Text {
+                id: sourcePaletteLabel
+                anchors {
+                    left: parent.left
+                    top: parent.top
+                }
+                text: "CURRENT THEME COLORS"
+                textFormat: Text.PlainText
+                color: root.theme.textSecondary
+                font {
+                    family: "monospace"
+                    pixelSize: 10
+                    weight: Font.DemiBold
+                    letterSpacing: 0.6
+                }
+            }
+
+            Row {
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    top: sourcePaletteLabel.bottom
+                    topMargin: 5
+                }
+                height: 48
+
+                Repeater {
+                    model: root.paletteRoles
+
+                    Item {
+                        required property string modelData
+                        width: parent.width / root.paletteRoles.length
+                        height: parent.height
+
+                        Column {
+                            anchors.centerIn: parent
+                            spacing: 3
+
+                            Rectangle {
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                width: 24
+                                height: 24
+                                radius: 12
+                                color: root.sourceColor(parent.parent.modelData)
+                                border.width: 1
+                                border.color: root.theme.textSecondary
+                            }
+
+                            Text {
+                                width: parent.parent.width - 4
+                                text: parent.parent.modelData.toUpperCase()
+                                textFormat: Text.PlainText
+                                color: root.theme.textMuted
+                                elide: Text.ElideRight
+                                horizontalAlignment: Text.AlignHCenter
+                                font {
+                                    family: "monospace"
+                                    pixelSize: 9
+                                    weight: Font.DemiBold
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Item {
+            width: parent.width
+            height: root.mappingTargets.length * 44
+
+            Column {
+                anchors.fill: parent
+
+                Repeater {
+                    model: root.mappingTargets
+
+                    Item {
+                        id: mappingRow
+                        required property var modelData
+                        width: parent.width
+                        height: 44
+
+                        Text {
+                            anchors {
+                                left: parent.left
+                                verticalCenter: parent.verticalCenter
+                            }
+                            width: 160
+                            text: mappingRow.modelData.label
+                            textFormat: Text.PlainText
+                            color: root.theme.textPrimary
+                            elide: Text.ElideRight
+                            font {
+                                family: "monospace"
+                                pixelSize: 11
+                                weight: Font.Bold
+                                letterSpacing: 0.5
+                            }
+                        }
+
+                        Row {
+                            anchors {
+                                left: parent.left
+                                right: parent.right
+                                leftMargin: 160
+                            }
+                            height: parent.height
+
+                            Repeater {
+                                model: root.paletteRoles
+
+                                Rectangle {
+                                    id: roleButton
+                                    required property string modelData
+                                    readonly property bool selected:
+                                        root.selectionFor(
+                                            mappingRow.modelData.id,
+                                            mappingRow.modelData.fallback
+                                        ) === modelData
+
+                                    objectName: "paletteRole_"
+                                        + mappingRow.modelData.id + "_"
+                                        + modelData
+                                    width: parent.width / root.paletteRoles.length
+                                    height: parent.height
+                                    radius: 10
+                                    color: roleTap.pressed
+                                        ? root.theme.surfacePressed
+                                        : selected
+                                            ? Qt.alpha(
+                                                root.sourceColor(modelData),
+                                                0.16
+                                            )
+                                            : "transparent"
+                                    border.width: selected ? 2 : 0
+                                    border.color: root.theme.textPrimary
+
+                                    function activate() {
+                                        return root.setMapping(
+                                            mappingRow.modelData.id,
+                                            modelData
+                                        )
+                                    }
+
+                                    Accessible.role: Accessible.RadioButton
+                                    Accessible.name: mappingRow.modelData.label
+                                        + " uses " + modelData
+                                    Accessible.checkable: true
+                                    Accessible.checked: selected
+                                    Accessible.onPressAction: activate()
+
+                                    Rectangle {
+                                        anchors.centerIn: parent
+                                        width: roleButton.selected ? 24 : 18
+                                        height: width
+                                        radius: width / 2
+                                        color: root.sourceColor(roleButton.modelData)
+                                        border.width: 1
+                                        border.color: root.theme.textSecondary
+
+                                        Text {
+                                            anchors.centerIn: parent
+                                            visible: roleButton.selected
+                                            text: "✓"
+                                            textFormat: Text.PlainText
+                                            color: ThemePalette.ensureContrast(
+                                                String(root.theme.textPrimary),
+                                                String(root.sourceColor(
+                                                    roleButton.modelData
+                                                )),
+                                                4.5
+                                            )
+                                            font {
+                                                family: "monospace"
+                                                pixelSize: 14
+                                                weight: Font.Bold
+                                            }
+                                        }
+                                    }
+
+                                    TapHandler {
+                                        id: roleTap
+                                        gesturePolicy:
+                                            TapHandler.ReleaseWithinBounds
+                                        onTapped: roleButton.activate()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Item {
+            width: parent.width
+            height: 44
+
+            Text {
+                anchors {
+                    left: parent.left
+                    verticalCenter: parent.verticalCenter
+                }
+                width: parent.width - resetButton.width - 18
+                text: "CHROME AND TEXT CONTRAST REMAIN AUTOMATIC"
+                textFormat: Text.PlainText
+                color: root.theme.textMuted
+                elide: Text.ElideRight
+                font {
+                    family: "monospace"
+                    pixelSize: 9
+                    letterSpacing: 0.5
+                }
+            }
+
+            Rectangle {
+                id: resetButton
+                objectName: "paletteResetButton"
+                anchors {
+                    right: parent.right
+                    verticalCenter: parent.verticalCenter
+                }
+                width: 150
+                height: 44
+                radius: 12
+                color: resetTap.pressed
+                    ? root.theme.surfacePressed
+                    : root.theme.surfaceRaised
+                border.width: 1
+                border.color: root.customized
+                    ? root.theme.accent
+                    : root.theme.border
+                enabled: root.customized
+
+                function activate() {
+                    if (!enabled)
+                        return false
+                    return root.resetMappings()
+                }
+
+                Accessible.role: Accessible.Button
+                Accessible.ignored: !enabled
+                Accessible.name: "Reset palette mappings"
+                Accessible.description: "Restore the reviewed default roles"
+                Accessible.onPressAction: activate()
+
+                Text {
+                    anchors.centerIn: parent
+                    text: "RESET DEFAULTS"
+                    textFormat: Text.PlainText
+                    color: resetButton.enabled
+                        ? root.theme.textPrimary
+                        : root.theme.textMuted
+                    font {
+                        family: "monospace"
+                        pixelSize: 9
+                        weight: Font.Bold
+                    }
+                }
+
+                TapHandler {
+                    id: resetTap
+                    enabled: resetButton.enabled
+                    gesturePolicy: TapHandler.ReleaseWithinBounds
+                    onTapped: resetButton.activate()
+                }
+            }
+        }
+    }
+}

--- a/quickshell/components/PortalBackground.qml
+++ b/quickshell/components/PortalBackground.qml
@@ -1,26 +1,30 @@
 import QtQuick
+import "../state/ThemePalette.js" as ThemePalette
 
 Item {
     id: root
 
+    property var theme: ThemePalette.fallback
     property bool reducedMotion: false
     property bool ambientMode: false
 
     Rectangle {
         anchors.fill: parent
-        color: "#02050b"
+        color: root.theme.canvas
         gradient: Gradient {
             GradientStop {
                 position: 0
-                color: root.ambientMode ? "#020813" : "#03101a"
+                color: root.theme.canvas
             }
             GradientStop {
                 position: 0.54
-                color: "#05091a"
+                color: root.theme.surface
             }
             GradientStop {
                 position: 1
-                color: root.ambientMode ? "#09051a" : "#100721"
+                color: root.ambientMode
+                    ? Qt.alpha(root.theme.magenta, 0.16)
+                    : Qt.alpha(root.theme.accent, 0.12)
             }
         }
     }
@@ -34,7 +38,7 @@ Item {
             x: index * 80
             width: 1
             height: root.height
-            color: index % 4 === 0 ? "#19436a" : "#102942"
+            color: root.theme.accent
             opacity: index % 4 === 0 ? 0.24 : 0.12
         }
     }
@@ -48,7 +52,7 @@ Item {
             y: index * 80
             width: root.width
             height: 1
-            color: index % 2 === 0 ? "#153c60" : "#10263d"
+            color: root.theme.border
             opacity: index % 2 === 0 ? 0.2 : 0.1
         }
     }
@@ -64,7 +68,9 @@ Item {
             width: index % 5 === 0 ? 4 : 2
             height: width
             radius: width / 2
-            color: index % 3 === 0 ? "#62f5ff" : "#9367ff"
+            color: index % 3 === 0
+                ? root.theme.accentSecondary
+                : root.theme.magenta
             opacity: 0.18 + (index % 4) * 0.08
         }
     }
@@ -79,7 +85,7 @@ Item {
         radius: height / 2
         color: "transparent"
         border.width: 2
-        border.color: "#173c7a"
+        border.color: root.theme.blue
         opacity: root.ambientMode ? 0.42 : 0.22
     }
 
@@ -89,7 +95,7 @@ Item {
         width: root.width
         height: 2
         y: -4
-        color: "#5cf6ff"
+        color: root.theme.accentSecondary
         opacity: 0.15
 
         NumberAnimation on y {

--- a/quickshell/components/PortalPalette.js
+++ b/quickshell/components/PortalPalette.js
@@ -1,15 +1,7 @@
 .pragma library
 
-// Mirrors the reviewed Codex Micro status palette. QML owns only presentation;
-// daemon and Herdr state remain authoritative.
-var working = "#0066ff"
-var blocked = "#ffaa00"
-var review = "#00ff00"
-var idle = "#303030"
-var error = "#ff2020"
-var unknown = "#300840"
-var recording = "#2e8b57"
-var processing = "#ffffff"
+// Maps authoritative state meaning onto the active Omarchy palette. QML owns
+// only presentation; daemon and Herdr state remain authoritative.
 
 function effectiveAgentState(agent) {
     if (agent === null || agent === undefined)
@@ -25,18 +17,18 @@ function effectiveAgentState(agent) {
     return "unknown"
 }
 
-function agentColor(agent) {
+function agentColor(agent, theme) {
     switch (effectiveAgentState(agent)) {
     case "working":
-        return working
+        return theme.blue
     case "blocked":
-        return blocked
+        return theme.yellow
     case "review":
-        return review
+        return theme.green
     case "idle":
-        return idle
+        return theme.muted
     default:
-        return unknown
+        return theme.magenta
     }
 }
 
@@ -84,23 +76,23 @@ function perimeterMode(agents) {
     return hasWorking ? "working" : "off"
 }
 
-function ambientColor(mode) {
+function ambientColor(mode, theme) {
     switch (mode) {
     case "voice-recording":
-        return recording
+        return theme.green
     case "voice-processing":
-        return processing
+        return theme.cyan
     case "voice-error":
     case "error":
-        return error
+        return theme.red
     case "blocked":
-        return blocked
+        return theme.yellow
     case "review":
-        return review
+        return theme.green
     case "working":
-        return working
+        return theme.blue
     default:
-        return "#000000"
+        return theme.muted
     }
 }
 

--- a/quickshell/components/PortalPalette.js
+++ b/quickshell/components/PortalPalette.js
@@ -20,15 +20,15 @@ function effectiveAgentState(agent) {
 function agentColor(agent, theme) {
     switch (effectiveAgentState(agent)) {
     case "working":
-        return theme.blue
+        return theme.working
     case "blocked":
-        return theme.yellow
+        return theme.needsHelp
     case "review":
-        return theme.green
+        return theme.reviewReady
     case "idle":
-        return theme.muted
+        return theme.ready
     default:
-        return theme.magenta
+        return theme.unknown
     }
 }
 
@@ -79,20 +79,20 @@ function perimeterMode(agents) {
 function ambientColor(mode, theme) {
     switch (mode) {
     case "voice-recording":
-        return theme.green
+        return theme.recording
     case "voice-processing":
-        return theme.cyan
+        return theme.processing
     case "voice-error":
     case "error":
-        return theme.red
+        return theme.error
     case "blocked":
-        return theme.yellow
+        return theme.needsHelp
     case "review":
-        return theme.green
+        return theme.reviewReady
     case "working":
-        return theme.blue
+        return theme.working
     default:
-        return theme.muted
+        return theme.ready
     }
 }
 

--- a/quickshell/components/PortalView.qml
+++ b/quickshell/components/PortalView.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import "../state/ThemePalette.js" as ThemePalette
 
 Item {
     id: root
@@ -7,18 +8,48 @@ Item {
     required property var bridge
     required property var activity
     required property var preferences
+    required property var theme
     property bool reducedMotion: false
     property bool previewMode: false
     property bool restoreVoiceFocus: false
     property bool previewMicroOpen: false
     property string hostName: "LOCAL"
 
-    readonly property int pageSize: 6
+    readonly property int pageSize: 14
     readonly property int pageCount: Math.max(
         1,
         Math.ceil(store.agents.length / pageSize)
     )
     readonly property string surfaceState: store.surfaceState()
+    readonly property color microStatusColor: store.micro.connected
+        ? theme.green
+        : theme.red
+    readonly property color readableMicroStatusColor:
+        ThemePalette.ensureContrast(
+            String(microStatusColor),
+            String(theme.surfaceRaised),
+            4.5
+        )
+    readonly property color degradedColor: theme.yellow
+    readonly property color readableDegradedColor:
+        ThemePalette.ensureContrast(
+            String(degradedColor),
+            String(theme.canvas),
+            4.5
+        )
+    readonly property color toastColor: toastSuccess
+        ? theme.green
+        : theme.red
+    readonly property color surfaceMessageColor:
+        surfaceState === "disconnected"
+            ? theme.red
+            : theme.accent
+    readonly property color readableSurfaceMessageColor:
+        ThemePalette.ensureContrast(
+            String(surfaceMessageColor),
+            String(theme.surface),
+            4.5
+        )
     readonly property bool userMotionReduced:
         preferences.reduceMotion === true
     readonly property bool displayDimmed:
@@ -37,7 +68,14 @@ Item {
     property bool toastVisible: false
     property var pendingVoiceFocus: ({})
     property var pendingDesktopActions: ({})
+    property string pendingAgentOrderRequest: ""
     property bool microDrawerOpen: false
+    readonly property bool agentOrderAvailable:
+        store.agentOrder !== undefined
+        && store.agentOrder.available === true
+    readonly property string agentOrderMode: agentOrderAvailable
+        ? String(store.agentOrder.mode)
+        : "grouped"
 
     clip: true
 
@@ -64,7 +102,7 @@ Item {
         var count = pageAgentCount(pageIndex)
         if (count <= 2)
             return Math.max(1, count)
-        return count <= 4 ? 2 : 3
+        return Math.ceil(count / 2)
     }
 
     function pageRows(pageIndex) {
@@ -145,6 +183,16 @@ Item {
         return true
     }
 
+    function requestAgentOrder(mode) {
+        if (!agentOrderAvailable || pendingAgentOrderRequest !== "")
+            return false
+        var requestId = bridge.setAgentOrder(mode)
+        if (requestId === "")
+            return false
+        pendingAgentOrderRequest = requestId
+        return true
+    }
+
     function toggleMotionReduction() {
         if (reducedMotion)
             return false
@@ -173,12 +221,14 @@ Item {
 
     PortalBackground {
         anchors.fill: parent
+        theme: root.theme
         reducedMotion: root.effectiveReducedMotion
         ambientMode: root.activity.ambientMode
     }
 
     AmbientRing {
         anchors.fill: parent
+        theme: root.theme
         agents: root.store.agents
         voice: root.store.voice
         connectionState: root.store.connection.state
@@ -218,6 +268,7 @@ Item {
         motionReduced: root.effectiveReducedMotion
         motionForced: root.reducedMotion
         dimmed: root.displayDimmed
+        theme: root.theme
         opacity: root.displayDimmed ? 0.58 : 1
         z: 80
         onMotionToggleRequested: root.toggleMotionReduction()
@@ -249,6 +300,8 @@ Item {
         }
 
         Row {
+            id: headerIdentity
+
             anchors {
                 left: parent.left
                 verticalCenter: parent.verticalCenter
@@ -259,7 +312,7 @@ Item {
                 width: 8
                 height: 52
                 radius: 4
-                color: "#55e9ff"
+                color: root.theme.accent
             }
 
             Column {
@@ -269,7 +322,7 @@ Item {
                     text: String(root.hostName || "LOCAL").toUpperCase()
                         + " // AGENT COMMAND"
                     textFormat: Text.PlainText
-                    color: "#ecfbff"
+                    color: root.theme.textPrimary
                     font {
                         family: "monospace"
                         pixelSize: 25
@@ -281,13 +334,93 @@ Item {
                 Text {
                     text: root.attentionSummary()
                     textFormat: Text.PlainText
-                    color: "#6385a5"
+                    color: root.theme.textMuted
                     font {
                         family: "monospace"
                         pixelSize: 13
                         letterSpacing: 0.6
                     }
                 }
+            }
+        }
+
+        Rectangle {
+            id: agentOrderToggle
+            objectName: "agentOrderToggle"
+
+            anchors {
+                left: headerIdentity.right
+                leftMargin: 44
+                verticalCenter: parent.verticalCenter
+            }
+            width: 184
+            height: 48
+            radius: 12
+            color: orderTap.pressed
+                ? root.theme.surfacePressed
+                : root.theme.surfaceRaised
+            border.width: 1
+            border.color: root.agentOrderAvailable
+                ? root.theme.accent
+                : root.theme.border
+            enabled: root.controlCenterInteractive
+                && root.agentOrderAvailable
+                && root.pendingAgentOrderRequest === ""
+
+            function activate() {
+                if (!enabled)
+                    return false
+                root.activity.noteUserActivity()
+                return root.requestAgentOrder(
+                    root.agentOrderMode === "grouped"
+                        ? "priority"
+                        : "grouped"
+                )
+            }
+
+            Accessible.role: Accessible.Button
+            // Disabled status is still meaningful: expose why synchronization
+            // is unavailable or currently in progress to assistive technology.
+            Accessible.ignored: false
+            Accessible.name: root.pendingAgentOrderRequest !== ""
+                ? "Agent ordering syncing"
+                : root.agentOrderAvailable
+                    ? "Agent ordering " + root.agentOrderMode
+                    : "Agent ordering unavailable"
+            Accessible.description: root.pendingAgentOrderRequest !== ""
+                ? "Synchronizing agent ordering with Herdr"
+                : root.agentOrderAvailable
+                    ? "Switch Herdr and the command center to "
+                    + (root.agentOrderMode === "grouped"
+                        ? "priority"
+                        : "grouped") + " ordering"
+                    : "Requires a Herdr version with agent ordering API support"
+            Accessible.onPressAction: activate()
+
+            Text {
+                objectName: "agentOrderLabel"
+                anchors.centerIn: parent
+                text: root.pendingAgentOrderRequest !== ""
+                    ? "ORDER // SYNCING"
+                    : root.agentOrderAvailable
+                        ? "ORDER // " + root.agentOrderMode.toUpperCase()
+                        : "ORDER // UNAVAILABLE"
+                textFormat: Text.PlainText
+                color: root.agentOrderAvailable
+                    ? root.theme.textPrimary
+                    : root.theme.textMuted
+                font {
+                    family: "monospace"
+                    pixelSize: 11
+                    weight: Font.DemiBold
+                    letterSpacing: 0.5
+                }
+            }
+
+            TapHandler {
+                id: orderTap
+                gesturePolicy: TapHandler.ReleaseWithinBounds
+                onTapped: agentOrderToggle.activate()
             }
         }
 
@@ -328,8 +461,8 @@ Item {
                         height: 8
                         radius: 4
                         color: parent.index === root.currentPage
-                            ? "#55e9ff"
-                            : "#29445f"
+                            ? root.theme.accent
+                            : root.theme.border
 
                         Behavior on width {
                             NumberAnimation {
@@ -360,7 +493,8 @@ Item {
                 height: 58
                 anchors.verticalCenter: parent.verticalCenter
                 label: "CHATGPT"
-                accent: "#6cf7b0"
+                accent: root.theme.green
+                theme: root.theme
                 pending: root.desktopActionPending("chatgpt_desktop")
                 enabled: root.controlCenterInteractive
                     && !root.store.freshSnapshotRequired
@@ -373,7 +507,8 @@ Item {
                 height: 58
                 anchors.verticalCenter: parent.verticalCenter
                 label: "CLAUDE"
-                accent: "#e89562"
+                accent: root.theme.orange
+                theme: root.theme
                 pending: root.desktopActionPending("claude_desktop")
                 enabled: root.controlCenterInteractive
                     && !root.store.freshSnapshotRequired
@@ -386,6 +521,7 @@ Item {
                 height: 58
                 anchors.verticalCenter: parent.verticalCenter
                 voice: root.store.voice
+                theme: root.theme
                 reducedMotion: root.effectiveReducedMotion
                 enabled: root.controlCenterInteractive
                 actionsEnabled: root.controlCenterInteractive
@@ -413,11 +549,11 @@ Item {
                 height: 58
                 radius: 14
                 anchors.verticalCenter: parent.verticalCenter
-                color: microTap.pressed ? "#14283a" : "#0b1523"
+                color: microTap.pressed
+                    ? root.theme.surfacePressed
+                    : root.theme.surfaceRaised
                 border.width: 1
-                border.color: root.store.micro.connected
-                    ? "#3a8d83"
-                    : "#583b49"
+                border.color: root.microStatusColor
                 enabled: root.controlCenterInteractive
 
                 function activate() {
@@ -446,9 +582,7 @@ Item {
                         radius: 14
                         color: "transparent"
                         border.width: 4
-                        border.color: root.store.micro.connected
-                            ? "#49e0cf"
-                            : "#604253"
+                        border.color: root.microStatusColor
                     }
 
                     Column {
@@ -458,7 +592,7 @@ Item {
                         Text {
                             text: "MICRO"
                             textFormat: Text.PlainText
-                            color: "#e8f8fc"
+                            color: root.theme.textPrimary
                             font {
                                 family: "monospace"
                                 pixelSize: 15
@@ -474,9 +608,7 @@ Item {
                                     : "CONNECTED"
                                 : "OFFLINE"
                             textFormat: Text.PlainText
-                            color: root.store.micro.connected
-                                ? "#65d9c5"
-                                : "#b07888"
+                            color: root.readableMicroStatusColor
                             font {
                                 family: "monospace"
                                 pixelSize: 9
@@ -498,6 +630,7 @@ Item {
     }
 
     Rectangle {
+        objectName: "degradedBanner"
         anchors {
             top: header.bottom
             horizontalCenter: parent.horizontalCenter
@@ -505,15 +638,16 @@ Item {
         width: 960
         height: root.surfaceState === "degraded" ? 28 : 0
         radius: 14
-        color: "#d4362b0f"
+        color: Qt.alpha(root.degradedColor, 0.16)
         border.width: height > 0 ? 1 : 0
-        border.color: "#7f5d30"
+        border.color: root.degradedColor
         clip: true
         visible: height > 0
         z: 12
         opacity: ambientView.controlCenterProgress
 
         Text {
+            objectName: "degradedBannerText"
             anchors.centerIn: parent
             text: "DEGRADED // " + String(
                 root.store.connection.detail
@@ -521,7 +655,7 @@ Item {
                     || "PARTIAL TELEMETRY"
             ).toUpperCase()
             textFormat: Text.PlainText
-            color: "#ffc47c"
+            color: root.readableDegradedColor
             elide: Text.ElideRight
             width: parent.width - 40
             horizontalAlignment: Text.AlignHCenter
@@ -542,6 +676,7 @@ Item {
 
     ListView {
         id: pages
+        objectName: "agentPages"
 
         anchors {
             left: parent.left
@@ -593,6 +728,7 @@ Item {
 
             Grid {
                 id: cardGrid
+                objectName: "agentGrid_" + page.index
 
                 anchors {
                     fill: parent
@@ -610,6 +746,7 @@ Item {
 
                     AgentCard {
                         required property int index
+                        objectName: "agentCard_" + page.index + "_" + index
 
                         width: (
                             cardGrid.width
@@ -622,6 +759,7 @@ Item {
                                     * (root.pageRows(page.index) - 1)
                         ) / root.pageRows(page.index)
                         agent: root.agentAt(page.index, index)
+                        theme: root.theme
                         visible: agent !== null
                         enabled: visible && root.controlCenterInteractive
                         reducedMotion: root.effectiveReducedMotion
@@ -683,11 +821,11 @@ Item {
         Rectangle {
             anchors.fill: parent
             radius: 22
-            color: "#e8050a14"
+            color: Qt.alpha(root.theme.surface, 0.92)
             border.width: 1
             border.color: root.surfaceState === "disconnected"
-                ? "#6f3047"
-                : "#244a67"
+                ? root.theme.red
+                : root.theme.border
         }
 
         Column {
@@ -702,9 +840,7 @@ Item {
                         ? "HERDR DISCONNECTED"
                         : "NO ACTIVE AGENTS"
                 textFormat: Text.PlainText
-                color: root.surfaceState === "disconnected"
-                    ? "#ff769a"
-                    : "#77eaff"
+                color: root.readableSurfaceMessageColor
                 font {
                     family: "monospace"
                     pixelSize: 30
@@ -725,7 +861,7 @@ Item {
                         )
                         : "Herdr is connected and has no running local agents"
                 textFormat: Text.PlainText
-                color: "#718ca6"
+                color: root.theme.textMuted
                 font {
                     family: "sans-serif"
                     pixelSize: 16
@@ -747,6 +883,7 @@ Item {
         }
         height: 106
         usage: root.store.usage
+        theme: root.theme
         agents: root.store.agents
         sessions: root.store.sessions
         reducedMotion: root.effectiveReducedMotion
@@ -765,6 +902,7 @@ Item {
         micro: root.store.micro
         agents: root.store.agents
         voice: root.store.voice
+        theme: root.theme
         z: 35
         opacity: ambientView.controlCenterProgress
         onInteracted: root.activity.noteUserActivity()
@@ -782,9 +920,9 @@ Item {
         width: 780
         height: root.toastVisible ? 74 : 0
         radius: 16
-        color: root.toastSuccess ? "#ed0b241f" : "#ed2b0e1a"
+        color: Qt.alpha(root.toastColor, 0.15)
         border.width: root.toastVisible ? 1 : 0
-        border.color: root.toastSuccess ? "#377f69" : "#8b3d58"
+        border.color: root.toastColor
         clip: true
         visible: height > 0
         z: 60
@@ -801,7 +939,7 @@ Item {
                 width: 8
                 height: parent.height
                 radius: 4
-                color: root.toastSuccess ? "#6cf7b0" : "#ff5d83"
+                color: root.toastColor
             }
 
             Column {
@@ -813,7 +951,7 @@ Item {
                     width: parent.width
                     text: root.toastTitle
                     textFormat: Text.PlainText
-                    color: "#e8fbff"
+                    color: root.theme.textPrimary
                     elide: Text.ElideRight
                     font {
                         family: "monospace"
@@ -827,7 +965,7 @@ Item {
                     width: parent.width
                     text: root.toastDetail
                     textFormat: Text.PlainText
-                    color: "#8eabc3"
+                    color: root.theme.textSecondary
                     elide: Text.ElideRight
                     font {
                         family: "sans-serif"
@@ -857,6 +995,18 @@ Item {
         target: root.store
 
         function onActionResultReceived(result) {
+            if (result.action === "order_grouped"
+                    || result.action === "order_priority") {
+                root.pendingAgentOrderRequest = ""
+                root.showToast(
+                    result.ok
+                        ? "ORDER // SYNCED"
+                        : "ORDER // " + String(result.code).toUpperCase(),
+                    result.message || result.request_id,
+                    result.ok
+                )
+                return
+            }
             if (result.action === "restore_focus") {
                 var intent = root.pendingVoiceFocus[result.request_id]
                 if (intent !== undefined) {
@@ -923,6 +1073,7 @@ Item {
             if (root.store.freshSnapshotRequired) {
                 root.pendingVoiceFocus = {}
                 root.pendingDesktopActions = {}
+                root.pendingAgentOrderRequest = ""
             }
         }
     }
@@ -955,6 +1106,7 @@ Item {
         health: root.store.health
         voice: root.store.voice
         connectionState: root.store.connection.state
+        theme: root.theme
         onWakeRequested: root.notePassiveInteraction()
     }
 }

--- a/quickshell/components/PortalView.qml
+++ b/quickshell/components/PortalView.qml
@@ -9,6 +9,7 @@ Item {
     required property var activity
     required property var preferences
     required property var theme
+    property var sourceTheme: theme
     property bool reducedMotion: false
     property bool previewMode: false
     property bool restoreVoiceFocus: false
@@ -22,15 +23,15 @@ Item {
     )
     readonly property string surfaceState: store.surfaceState()
     readonly property color microStatusColor: store.micro.connected
-        ? theme.green
-        : theme.red
+        ? theme.success
+        : theme.error
     readonly property color readableMicroStatusColor:
         ThemePalette.ensureContrast(
             String(microStatusColor),
             String(theme.surfaceRaised),
             4.5
         )
-    readonly property color degradedColor: theme.yellow
+    readonly property color degradedColor: theme.needsHelp
     readonly property color readableDegradedColor:
         ThemePalette.ensureContrast(
             String(degradedColor),
@@ -38,11 +39,11 @@ Item {
             4.5
         )
     readonly property color toastColor: toastSuccess
-        ? theme.green
-        : theme.red
+        ? theme.success
+        : theme.error
     readonly property color surfaceMessageColor:
         surfaceState === "disconnected"
-            ? theme.red
+            ? theme.error
             : theme.accent
     readonly property color readableSurfaceMessageColor:
         ThemePalette.ensureContrast(
@@ -60,6 +61,7 @@ Item {
         !activity.ambientMode
         && ambientView.controlCenterProgress >= 0.999
         && !ambientView.exitShield
+        && !paletteSettingsOpen
     property int currentPage: 0
     property bool userPaging: false
     property string toastTitle: ""
@@ -70,6 +72,7 @@ Item {
     property var pendingDesktopActions: ({})
     property string pendingAgentOrderRequest: ""
     property bool microDrawerOpen: false
+    property bool paletteSettingsOpen: false
     readonly property bool agentOrderAvailable:
         store.agentOrder !== undefined
         && store.agentOrder.available === true
@@ -209,6 +212,14 @@ Item {
         return true
     }
 
+    function togglePaletteSettings() {
+        activity.noteUserActivity()
+        paletteSettingsOpen = !paletteSettingsOpen
+        if (paletteSettingsOpen)
+            microDrawerOpen = false
+        return true
+    }
+
     onPageCountChanged: {
         currentPage = Math.min(currentPage, pageCount - 1)
         pages.positionViewAtIndex(currentPage, ListView.SnapPosition)
@@ -217,6 +228,15 @@ Item {
     onControlCenterInteractiveChanged: {
         if (!controlCenterInteractive)
             microDrawerOpen = false
+    }
+
+    Connections {
+        target: root.activity
+
+        function onAmbientModeChanged() {
+            if (root.activity.ambientMode)
+                root.paletteSettingsOpen = false
+        }
     }
 
     PortalBackground {
@@ -255,6 +275,25 @@ Item {
         }
     }
 
+    Rectangle {
+        objectName: "paletteModalScrim"
+        anchors.fill: parent
+        visible: root.paletteSettingsOpen
+        color: "#000000"
+        opacity: 0.46
+        z: 68
+
+        Accessible.ignored: true
+
+        TapHandler {
+            gesturePolicy: TapHandler.ReleaseWithinBounds
+            onTapped: {
+                root.activity.noteUserActivity()
+                root.paletteSettingsOpen = false
+            }
+        }
+    }
+
     DisplaySettingsControls {
         id: displaySettings
 
@@ -268,11 +307,14 @@ Item {
         motionReduced: root.effectiveReducedMotion
         motionForced: root.reducedMotion
         dimmed: root.displayDimmed
+        paletteOpen: root.paletteSettingsOpen
+        paletteCustom: paletteSettings.customized
         theme: root.theme
         opacity: root.displayDimmed ? 0.58 : 1
         z: 80
         onMotionToggleRequested: root.toggleMotionReduction()
         onDimToggleRequested: root.toggleDisplayDim()
+        onPaletteToggleRequested: root.togglePaletteSettings()
 
         Behavior on opacity {
             NumberAnimation {
@@ -280,6 +322,24 @@ Item {
                 easing.type: Easing.OutCubic
             }
         }
+    }
+
+    PaletteSettingsPane {
+        id: paletteSettings
+
+        anchors {
+            right: parent.right
+            top: parent.top
+            rightMargin: 24
+            topMargin: 82
+        }
+        open: root.paletteSettingsOpen
+        preferences: root.preferences
+        sourceTheme: root.sourceTheme
+        theme: root.theme
+        z: 69
+        onCloseRequested: root.paletteSettingsOpen = false
+        onInteractionOccurred: root.activity.noteUserActivity()
     }
 
     Item {
@@ -824,7 +884,7 @@ Item {
             color: Qt.alpha(root.theme.surface, 0.92)
             border.width: 1
             border.color: root.surfaceState === "disconnected"
-                ? root.theme.red
+                ? root.theme.error
                 : root.theme.border
         }
 

--- a/quickshell/components/PortalViewport.qml
+++ b/quickshell/components/PortalViewport.qml
@@ -8,6 +8,7 @@ Item {
     required property var activity
     required property var preferences
     required property var theme
+    property var sourceTheme: theme
     property bool reducedMotion: false
     property bool previewMode: false
     property bool restoreVoiceFocus: false
@@ -45,6 +46,7 @@ Item {
             activity: root.activity
             preferences: root.preferences
             theme: root.theme
+            sourceTheme: root.sourceTheme
             reducedMotion: root.reducedMotion
             previewMode: root.previewMode
             restoreVoiceFocus: root.restoreVoiceFocus

--- a/quickshell/components/PortalViewport.qml
+++ b/quickshell/components/PortalViewport.qml
@@ -7,6 +7,7 @@ Item {
     required property var bridge
     required property var activity
     required property var preferences
+    required property var theme
     property bool reducedMotion: false
     property bool previewMode: false
     property bool restoreVoiceFocus: false
@@ -24,7 +25,7 @@ Item {
 
     Rectangle {
         anchors.fill: parent
-        color: "#02050b"
+        color: root.theme.canvas
     }
 
     Item {
@@ -43,6 +44,7 @@ Item {
             bridge: root.bridge
             activity: root.activity
             preferences: root.preferences
+            theme: root.theme
             reducedMotion: root.reducedMotion
             previewMode: root.previewMode
             restoreVoiceFocus: root.restoreVoiceFocus

--- a/quickshell/components/VoiceControl.qml
+++ b/quickshell/components/VoiceControl.qml
@@ -21,12 +21,12 @@ Item {
     readonly property bool available: voice.available === true
     readonly property bool daemonOwned: voice.owned === true
     readonly property color accent: voiceState === "recording"
-        ? theme.green
+        ? theme.recording
         : voiceState === "processing"
-            ? theme.cyan
+            ? theme.processing
             : voiceState === "error"
-                ? theme.red
-                : theme.muted
+                ? theme.error
+                : theme.ready
     readonly property color controlBackground:
         pressHandler.pressed || voiceState === "recording"
             ? ThemePalette.mixColors(
@@ -259,10 +259,10 @@ Item {
         height: parent.height - 14
         radius: height / 2
         color: cancelHandler.pressed
-            ? Qt.alpha(root.theme.red, 0.28)
-            : Qt.alpha(root.theme.red, 0.14)
+            ? Qt.alpha(root.theme.error, 0.28)
+            : Qt.alpha(root.theme.error, 0.14)
         border.width: 1
-        border.color: root.theme.red
+        border.color: root.theme.error
         z: 4
 
         Accessible.role: Accessible.Button
@@ -280,7 +280,7 @@ Item {
             text: "CANCEL"
             textFormat: Text.PlainText
             color: ThemePalette.ensureContrast(
-                String(root.theme.red),
+                String(root.theme.error),
                 String(root.theme.surfaceRaised),
                 4.5
             )

--- a/quickshell/components/VoiceControl.qml
+++ b/quickshell/components/VoiceControl.qml
@@ -1,10 +1,11 @@
 import QtQuick
-import "PortalPalette.js" as Palette
+import "../state/ThemePalette.js" as ThemePalette
 
 Item {
     id: root
 
     property var voice: ({})
+    property var theme: ThemePalette.fallback
     property bool reducedMotion: false
     property bool actionsEnabled: true
     property bool pressOwned: false
@@ -20,12 +21,30 @@ Item {
     readonly property bool available: voice.available === true
     readonly property bool daemonOwned: voice.owned === true
     readonly property color accent: voiceState === "recording"
-        ? Palette.recording
+        ? theme.green
         : voiceState === "processing"
-            ? Palette.processing
+            ? theme.cyan
             : voiceState === "error"
-                ? Palette.error
-                : "#6f8ba8"
+                ? theme.red
+                : theme.muted
+    readonly property color controlBackground:
+        pressHandler.pressed || voiceState === "recording"
+            ? ThemePalette.mixColors(
+                String(theme.surfaceRaised),
+                String(accent),
+                0.2
+            )
+            : theme.surfaceRaised
+    readonly property color readableAccent: ThemePalette.ensureContrast(
+        String(accent),
+        String(controlBackground),
+        4.5
+    )
+    readonly property color readableSecondary: ThemePalette.ensureContrast(
+        String(theme.textMuted),
+        String(controlBackground),
+        4.5
+    )
     readonly property bool ownedError: voiceState === "error"
         && daemonOwned
     readonly property string stateLabel: voiceState === "recording"
@@ -92,9 +111,7 @@ Item {
     Rectangle {
         anchors.fill: parent
         radius: height / 2
-        color: pressHandler.pressed || root.voiceState === "recording"
-            ? Qt.alpha(root.accent, 0.2)
-            : "#0b1422"
+        color: root.controlBackground
         border.width: root.voiceState === "recording" ? 2 : 1
         border.color: Qt.alpha(root.accent, root.available ? 0.72 : 0.28)
 
@@ -194,7 +211,7 @@ Item {
             width: parent.width
             text: root.stateLabel
             textFormat: Text.PlainText
-            color: root.accent
+            color: root.readableAccent
             elide: Text.ElideRight
             font {
                 family: "monospace"
@@ -216,7 +233,7 @@ Item {
                             : "RETRY OR CHECK VOXTYPE"
                     : "OMARCHY // VOXTYPE"
             textFormat: Text.PlainText
-            color: "#617f9c"
+            color: root.readableSecondary
             elide: Text.ElideRight
             font {
                 family: "monospace"
@@ -241,9 +258,11 @@ Item {
         width: 68
         height: parent.height - 14
         radius: height / 2
-        color: cancelHandler.pressed ? "#401420" : "#22101a"
+        color: cancelHandler.pressed
+            ? Qt.alpha(root.theme.red, 0.28)
+            : Qt.alpha(root.theme.red, 0.14)
         border.width: 1
-        border.color: "#8f3a55"
+        border.color: root.theme.red
         z: 4
 
         Accessible.role: Accessible.Button
@@ -260,7 +279,11 @@ Item {
             anchors.centerIn: parent
             text: "CANCEL"
             textFormat: Text.PlainText
-            color: "#ff789a"
+            color: ThemePalette.ensureContrast(
+                String(root.theme.red),
+                String(root.theme.surfaceRaised),
+                4.5
+            )
             font {
                 family: "monospace"
                 pixelSize: 10

--- a/quickshell/shell.qml
+++ b/quickshell/shell.qml
@@ -131,6 +131,10 @@ ShellRoot {
             id: portalStore
         }
 
+        OmarchyTheme {
+            id: portalTheme
+        }
+
         ActivityController {
             id: activityController
             inactivityMs: root.previewWindowMode
@@ -177,6 +181,7 @@ ShellRoot {
                 bridge: portalBridge
                 activity: activityController
                 preferences: portalPreferences
+                theme: portalTheme
                 reducedMotion: root.reducedMotion
                 hostName: root.hostName
             }
@@ -191,7 +196,7 @@ ShellRoot {
         implicitWidth: 1280
         implicitHeight: 360
         minimumSize: Qt.size(960, 270)
-        color: "#02050b"
+        color: portalTheme.canvas
         surfaceFormat.opaque: true
 
         onClosed: {
@@ -212,6 +217,7 @@ ShellRoot {
             bridge: portalBridge
             activity: activityController
             preferences: portalPreferences
+            theme: portalTheme
             reducedMotion: root.reducedMotion
             previewMode: root.previewMode
             restoreVoiceFocus: root.livePreviewMode

--- a/quickshell/shell.qml
+++ b/quickshell/shell.qml
@@ -125,6 +125,15 @@ ShellRoot {
             category: "display"
             property bool reduceMotion: false
             property bool dimmed: false
+            property string readyColorRole: "muted"
+            property string successColorRole: "green"
+            property string workingColorRole: "blue"
+            property string needsHelpColorRole: "yellow"
+            property string reviewReadyColorRole: "green"
+            property string errorColorRole: "red"
+            property string unknownColorRole: "magenta"
+            property string recordingColorRole: "green"
+            property string processingColorRole: "cyan"
         }
 
         PortalStore {
@@ -133,6 +142,12 @@ ShellRoot {
 
         OmarchyTheme {
             id: portalTheme
+        }
+
+        MappedTheme {
+            id: mappedTheme
+            sourceTheme: portalTheme
+            preferences: portalPreferences
         }
 
         ActivityController {
@@ -181,7 +196,8 @@ ShellRoot {
                 bridge: portalBridge
                 activity: activityController
                 preferences: portalPreferences
-                theme: portalTheme
+                theme: mappedTheme
+                sourceTheme: portalTheme
                 reducedMotion: root.reducedMotion
                 hostName: root.hostName
             }
@@ -196,7 +212,7 @@ ShellRoot {
         implicitWidth: 1280
         implicitHeight: 360
         minimumSize: Qt.size(960, 270)
-        color: portalTheme.canvas
+        color: mappedTheme.canvas
         surfaceFormat.opaque: true
 
         onClosed: {
@@ -217,7 +233,8 @@ ShellRoot {
             bridge: portalBridge
             activity: activityController
             preferences: portalPreferences
-            theme: portalTheme
+            theme: mappedTheme
+            sourceTheme: portalTheme
             reducedMotion: root.reducedMotion
             previewMode: root.previewMode
             restoreVoiceFocus: root.livePreviewMode

--- a/quickshell/state/CommandBuilder.qml
+++ b/quickshell/state/CommandBuilder.qml
@@ -13,7 +13,9 @@ QtObject {
         "claude_desktop",
         "voice_start",
         "voice_stop",
-        "voice_cancel"
+        "voice_cancel",
+        "order_grouped",
+        "order_priority"
     ]
 
     property int requestCounter: 0
@@ -47,6 +49,8 @@ QtObject {
             || action === "voice_start"
             || action === "voice_stop"
             || action === "voice_cancel"
+            || action === "order_grouped"
+            || action === "order_priority"
 
         if (systemAction) {
             if (normalizedAgentId !== ""

--- a/quickshell/state/MappedTheme.qml
+++ b/quickshell/state/MappedTheme.qml
@@ -1,0 +1,67 @@
+import QtQuick
+import "ThemePalette.js" as ThemePalette
+
+QtObject {
+    id: root
+
+    required property var sourceTheme
+    required property var preferences
+
+    readonly property var selectableRoles: ThemePalette.selectableRoles
+
+    function mappedColor(preferenceName, fallbackRole) {
+        return ThemePalette.roleColor(
+            sourceTheme,
+            preferences[preferenceName],
+            fallbackRole
+        )
+    }
+
+    // Raw Omarchy roles remain available for chrome and provider accents.
+    readonly property string mode: sourceTheme.mode
+    readonly property color background: sourceTheme.background
+    readonly property color darkBackground: sourceTheme.darkBackground
+    readonly property color lighterBackground: sourceTheme.lighterBackground
+    readonly property color foreground: sourceTheme.foreground
+    readonly property color muted: sourceTheme.muted
+    readonly property color accent: sourceTheme.accent
+    readonly property color red: sourceTheme.red
+    readonly property color green: sourceTheme.green
+    readonly property color yellow: sourceTheme.yellow
+    readonly property color blue: sourceTheme.blue
+    readonly property color magenta: sourceTheme.magenta
+    readonly property color cyan: sourceTheme.cyan
+    readonly property color orange: sourceTheme.orange
+
+    readonly property color canvas: sourceTheme.canvas
+    readonly property color surface: sourceTheme.surface
+    readonly property color surfaceRaised: sourceTheme.surfaceRaised
+    readonly property color surfacePressed: sourceTheme.surfacePressed
+    readonly property color textPrimary: sourceTheme.textPrimary
+    readonly property color textSecondary: sourceTheme.textSecondary
+    readonly property color textMuted: sourceTheme.textMuted
+    readonly property color border: sourceTheme.border
+    readonly property color borderStrong: sourceTheme.borderStrong
+    readonly property color accentSecondary: sourceTheme.accentSecondary
+
+    // XENEON semantic roles are independently assignable to current Omarchy
+    // palette entries. No arbitrary colors cross this presentation boundary.
+    readonly property color ready:
+        mappedColor("readyColorRole", "muted")
+    readonly property color success:
+        mappedColor("successColorRole", "green")
+    readonly property color working:
+        mappedColor("workingColorRole", "blue")
+    readonly property color needsHelp:
+        mappedColor("needsHelpColorRole", "yellow")
+    readonly property color reviewReady:
+        mappedColor("reviewReadyColorRole", "green")
+    readonly property color error:
+        mappedColor("errorColorRole", "red")
+    readonly property color unknown:
+        mappedColor("unknownColorRole", "magenta")
+    readonly property color recording:
+        mappedColor("recordingColorRole", "green")
+    readonly property color processing:
+        mappedColor("processingColorRole", "cyan")
+}

--- a/quickshell/state/OmarchyTheme.qml
+++ b/quickshell/state/OmarchyTheme.qml
@@ -1,0 +1,134 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "ThemePalette.js" as ThemePalette
+
+Scope {
+    id: root
+
+    property string themeRoot: {
+        var override = String(
+            Quickshell.env("XENEON_EDGE_THEME_ROOT") || ""
+        )
+        if (override !== "")
+            return override
+        var stateHome = String(Quickshell.env("XDG_STATE_HOME") || "")
+        if (stateHome === "")
+            stateHome = String(Quickshell.env("HOME") || "")
+                + "/.local/state"
+        return stateHome + "/omarchy/current"
+    }
+    readonly property string themeNamePath: themeRoot + "/theme.name"
+    readonly property string colorsPath: themeRoot + "/theme/colors.toml"
+
+    property string themeName: ""
+    property bool paletteLoaded: false
+    property int paletteGeneration: 0
+    property string colorsReadPath: ""
+
+    property string mode: ThemePalette.fallback.mode
+    property color background: ThemePalette.fallback.background
+    property color darkBackground: ThemePalette.fallback.darkBackground
+    property color lighterBackground: ThemePalette.fallback.lighterBackground
+    property color foreground: ThemePalette.fallback.foreground
+    property color muted: ThemePalette.fallback.muted
+    property color accent: ThemePalette.fallback.accent
+    property color red: ThemePalette.fallback.red
+    property color green: ThemePalette.fallback.green
+    property color yellow: ThemePalette.fallback.yellow
+    property color blue: ThemePalette.fallback.blue
+    property color magenta: ThemePalette.fallback.magenta
+    property color cyan: ThemePalette.fallback.cyan
+    property color orange: ThemePalette.fallback.orange
+
+    property color canvas: ThemePalette.fallback.canvas
+    property color surface: ThemePalette.fallback.surface
+    property color surfaceRaised: ThemePalette.fallback.surfaceRaised
+    property color surfacePressed: ThemePalette.fallback.surfacePressed
+    property color textPrimary: ThemePalette.fallback.textPrimary
+    property color textSecondary: ThemePalette.fallback.textSecondary
+    property color textMuted: ThemePalette.fallback.textMuted
+    property color border: ThemePalette.fallback.border
+    property color borderStrong: ThemePalette.fallback.borderStrong
+    property color accentSecondary: ThemePalette.fallback.accentSecondary
+
+    function applyPaletteText(text) {
+        var palette = ThemePalette.parse(text)
+        mode = palette.mode
+        background = palette.background
+        darkBackground = palette.darkBackground
+        lighterBackground = palette.lighterBackground
+        foreground = palette.foreground
+        muted = palette.muted
+        accent = palette.accent
+        red = palette.red
+        green = palette.green
+        yellow = palette.yellow
+        blue = palette.blue
+        magenta = palette.magenta
+        cyan = palette.cyan
+        orange = palette.orange
+        canvas = palette.canvas
+        surface = palette.surface
+        surfaceRaised = palette.surfaceRaised
+        surfacePressed = palette.surfacePressed
+        textPrimary = palette.textPrimary
+        textSecondary = palette.textSecondary
+        textMuted = palette.textMuted
+        border = palette.border
+        borderStrong = palette.borderStrong
+        accentSecondary = palette.accentSecondary
+        paletteLoaded = true
+        paletteGeneration += 1
+    }
+
+    function resetPalette() {
+        applyPaletteText("")
+        paletteLoaded = false
+    }
+
+    function requestPaletteReload() {
+        // A same-path reload is ignored while FileView has an async operation
+        // in flight. Clearing the path cancels/disowns that read; restoring it
+        // after the debounce always opens the post-swap file.
+        colorsReadPath = ""
+        paletteReloadDebounce.restart()
+    }
+
+    FileView {
+        id: themeNameReader
+        path: root.themeNamePath
+        watchChanges: true
+        printErrors: false
+
+        onLoaded: {
+            root.themeName = String(themeNameReader.text() || "").trim()
+            root.requestPaletteReload()
+        }
+        onLoadFailed: {
+            root.themeName = ""
+            root.resetPalette()
+        }
+        onFileChanged: {
+            root.requestPaletteReload()
+            themeNameReader.reload()
+        }
+    }
+
+    Timer {
+        id: paletteReloadDebounce
+        interval: 40
+        repeat: false
+        onTriggered: root.colorsReadPath = root.colorsPath
+    }
+
+    FileView {
+        id: colorsReader
+        path: root.colorsReadPath
+        watchChanges: false
+        printErrors: false
+
+        onLoaded: root.applyPaletteText(colorsReader.text())
+        onLoadFailed: root.resetPalette()
+    }
+}

--- a/quickshell/state/PortalBridge.qml
+++ b/quickshell/state/PortalBridge.qml
@@ -170,4 +170,12 @@ QtObject {
     function cancelVoice() {
         return sendBuilt("voice_cancel", "", "", store.sequence)
     }
+
+    function setAgentOrder(mode) {
+        if (mode !== "grouped" && mode !== "priority") {
+            commandRejected("Agent order must be grouped or priority")
+            return ""
+        }
+        return sendBuilt("order_" + mode, "", "", store.sequence)
+    }
 }

--- a/quickshell/state/PortalStore.qml
+++ b/quickshell/state/PortalStore.qml
@@ -22,6 +22,10 @@ QtObject {
     })
     property var sessions: []
     property var agents: []
+    property var agentOrder: ({
+        "available": false,
+        "mode": "grouped"
+    })
     property var health: ({})
     property var voice: ({
         "available": false,
@@ -97,6 +101,7 @@ QtObject {
         }
         sessions = []
         agents = []
+        agentOrder = {"available": false, "mode": "grouped"}
         health = {}
         voice = {
             "available": false,
@@ -214,6 +219,10 @@ QtObject {
                 0,
                 Math.floor(finiteNumber(value.source_order, 0))
             ),
+            "state_change_seq": Math.max(
+                0,
+                Math.floor(finiteNumber(value.state_change_seq, 0))
+            ),
             "actions": {
                 "open": rawActions.open === true,
                 "zoom": rawActions.zoom === true,
@@ -229,7 +238,7 @@ QtObject {
         }
     }
 
-    function normalizeAgents(values) {
+    function normalizeAgents(values, orderMode) {
         var normalized = []
         for (var index = 0; index < values.length; index += 1) {
             var agent = normalizeAgent(values[index])
@@ -238,18 +247,40 @@ QtObject {
         }
 
         normalized.sort(function(left, right) {
+            if (orderMode === "grouped") {
+                if (left.source_order !== right.source_order)
+                    return left.source_order - right.source_order
+                return left.id.localeCompare(right.id)
+            }
             var priorityDifference = statePriority(
                 left.status,
                 left.review_ready
             ) - statePriority(right.status, right.review_ready)
             if (priorityDifference !== 0)
                 return priorityDifference
+            if (left.state_change_seq !== right.state_change_seq)
+                return right.state_change_seq - left.state_change_seq
             if (left.source_order !== right.source_order)
                 return left.source_order - right.source_order
             return left.id.localeCompare(right.id)
         })
 
         return normalized
+    }
+
+    function normalizeAgentOrder(value) {
+        var source = value !== null
+                && value !== undefined
+                && typeof value === "object"
+            ? value
+            : {}
+        var mode = safeString(source.mode, "grouped", 16).toLowerCase()
+        if (mode !== "grouped" && mode !== "priority")
+            mode = "grouped"
+        return {
+            "available": source.available === true,
+            "mode": mode
+        }
     }
 
     function normalizeSessions(values) {
@@ -279,13 +310,14 @@ QtObject {
                 "last_sync_ms": Math.max(
                     0,
                     finiteNumber(session.last_sync_ms, 0)
-                )
+                ),
+                "message": safeString(session.message, "", 160)
             })
         }
         return normalized
     }
 
-    function normalizeConnection(value) {
+    function normalizeConnection(value, sessionViews) {
         var state = safeString(value, "degraded", 24).toLowerCase()
         if (allowedConnectionStates.indexOf(state) === -1)
             state = "degraded"
@@ -296,9 +328,19 @@ QtObject {
             "reconnecting": "Reconnecting to Herdr",
             "offline": "Herdr is offline"
         }
+        var detail = details[state]
+        if (state === "degraded" || state === "reconnecting") {
+            for (var index = 0; index < sessionViews.length; index += 1) {
+                if (sessionViews[index].state === "incompatible"
+                        && sessionViews[index].message !== "") {
+                    detail = sessionViews[index].message
+                    break
+                }
+            }
+        }
         return {
             "state": state,
-            "detail": details[state]
+            "detail": detail
         }
     }
 
@@ -626,8 +668,16 @@ QtObject {
 
         var hadSnapshot = hasSnapshot
         var previousSignature = activitySignature
-        var nextConnection = normalizeConnection(snapshot.connection)
-        var nextAgents = normalizeAgents(snapshot.agents)
+        var nextSessions = normalizeSessions(snapshot.sessions)
+        var nextConnection = normalizeConnection(
+            snapshot.connection,
+            nextSessions
+        )
+        var nextAgentOrder = normalizeAgentOrder(snapshot.agent_order)
+        var nextAgents = normalizeAgents(
+            snapshot.agents,
+            nextAgentOrder.available ? nextAgentOrder.mode : "priority"
+        )
         var nextVoice = normalizeVoice(snapshot.voice)
         var nextUsage = normalizeUsage(snapshot.usage)
         var nextMicro = normalizeMicro(snapshot.micro)
@@ -640,8 +690,9 @@ QtObject {
         sequence = nextSequence
         generatedAtMs = nextGeneratedAtMs
         connection = nextConnection
-        sessions = normalizeSessions(snapshot.sessions)
+        sessions = nextSessions
         agents = nextAgents
+        agentOrder = nextAgentOrder
         health = normalizeHealth(snapshot.health)
         voice = nextVoice
         usage = nextUsage

--- a/quickshell/state/ThemePalette.js
+++ b/quickshell/state/ThemePalette.js
@@ -1,0 +1,199 @@
+.pragma library
+
+// Safe presentation defaults used when Omarchy is absent or publishes an
+// incomplete palette. Agent state colors intentionally live elsewhere.
+var rawFallback = {
+    mode: "dark",
+    background: "#02050b",
+    darkBackground: "#05091a",
+    lighterBackground: "#0b1523",
+    foreground: "#ecfbff",
+    muted: "#718ca6",
+    accent: "#55e9ff",
+    red: "#ff5d83",
+    green: "#6cf7b0",
+    yellow: "#ffc47c",
+    blue: "#55e9ff",
+    magenta: "#9a7cff",
+    cyan: "#55e9ff",
+    orange: "#e89562"
+}
+
+var linePattern = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"([^"]+)"/
+
+function validColor(value) {
+    return typeof value === "string"
+        && /^#[0-9A-Fa-f]{6}$/.test(value)
+}
+
+function parseAll(text) {
+    var values = {}
+    var lines = String(text || "").split("\n")
+    for (var index = 0; index < lines.length; index += 1) {
+        var match = lines[index].match(linePattern)
+        if (match !== null)
+            values[match[1].toLowerCase()] = match[2]
+    }
+    return values
+}
+
+function firstColor(values, keys, fallbackValue) {
+    for (var index = 0; index < keys.length; index += 1) {
+        var value = values[keys[index]]
+        if (validColor(value))
+            return value
+    }
+    return fallbackValue
+}
+
+function colorChannels(value) {
+    if (!validColor(value))
+        return [0, 0, 0]
+    return [
+        parseInt(value.slice(1, 3), 16),
+        parseInt(value.slice(3, 5), 16),
+        parseInt(value.slice(5, 7), 16)
+    ]
+}
+
+function colorString(channels) {
+    var result = "#"
+    for (var index = 0; index < 3; index += 1) {
+        var channel = Math.max(0, Math.min(255, Math.round(channels[index])))
+        result += channel.toString(16).padStart(2, "0")
+    }
+    return result
+}
+
+function mixColors(first, second, amount) {
+    var left = colorChannels(first)
+    var right = colorChannels(second)
+    var weight = Math.max(0, Math.min(1, Number(amount)))
+    return colorString([
+        left[0] * (1 - weight) + right[0] * weight,
+        left[1] * (1 - weight) + right[1] * weight,
+        left[2] * (1 - weight) + right[2] * weight
+    ])
+}
+
+function linearChannel(channel) {
+    var value = channel / 255
+    return value <= 0.04045
+        ? value / 12.92
+        : Math.pow((value + 0.055) / 1.055, 2.4)
+}
+
+function relativeLuminance(value) {
+    var channels = colorChannels(value)
+    return 0.2126 * linearChannel(channels[0])
+        + 0.7152 * linearChannel(channels[1])
+        + 0.0722 * linearChannel(channels[2])
+}
+
+function contrastRatio(first, second) {
+    var left = relativeLuminance(first)
+    var right = relativeLuminance(second)
+    return (Math.max(left, right) + 0.05)
+        / (Math.min(left, right) + 0.05)
+}
+
+function ensureContrast(candidate, background, minimum) {
+    if (contrastRatio(candidate, background) >= minimum)
+        return candidate
+
+    var black = "#000000"
+    var white = "#ffffff"
+    var target = contrastRatio(black, background)
+            >= contrastRatio(white, background)
+        ? black
+        : white
+    var low = 0
+    var high = 1
+    for (var iteration = 0; iteration < 12; iteration += 1) {
+        var middle = (low + high) / 2
+        if (contrastRatio(
+                mixColors(candidate, target, middle), background
+            ) >= minimum)
+            high = middle
+        else
+            low = middle
+    }
+    return mixColors(candidate, target, high)
+}
+
+function semantic(raw) {
+    var light = raw.mode === "light"
+    // The EDGE remains a dark command surface even for a light desktop theme.
+    // Light palettes still supply every semantic hue and are inverted only
+    // for chrome luminance roles.
+    var canvas = light
+        ? mixColors(raw.foreground, "#000000", 0.62)
+        : raw.background
+    var surface = light
+        ? mixColors(canvas, raw.accent, 0.06)
+        : mixColors(raw.background, raw.lighterBackground, 0.34)
+    var surfaceRaised = light
+        ? mixColors(canvas, raw.accent, 0.12)
+        : mixColors(raw.background, raw.lighterBackground, 0.68)
+    var primaryCandidate = light ? raw.background : raw.foreground
+    var textPrimary = ensureContrast(primaryCandidate, surface, 7)
+    var textMuted = ensureContrast(raw.muted, surface, 4.5)
+
+    return Object.assign({}, raw, {
+        canvas: canvas,
+        surface: surface,
+        surfaceRaised: surfaceRaised,
+        surfacePressed: mixColors(surfaceRaised, raw.accent, 0.18),
+        textPrimary: textPrimary,
+        textSecondary: ensureContrast(
+            mixColors(textPrimary, textMuted, 0.34), surface, 4.5
+        ),
+        textMuted: textMuted,
+        border: mixColors(raw.muted, raw.accent, 0.32),
+        borderStrong: mixColors(raw.muted, raw.accent, 0.68),
+        accentSecondary: raw.cyan
+    })
+}
+
+function parse(text) {
+    var values = parseAll(text)
+    var mode = String(values.mode || "").toLowerCase()
+    if (mode !== "light" && mode !== "dark")
+        mode = rawFallback.mode
+
+    var background = firstColor(
+        values, ["background", "bg"], rawFallback.background
+    )
+    var foreground = firstColor(
+        values, ["foreground", "fg"], rawFallback.foreground
+    )
+    var raw = {
+        mode: mode,
+        background: background,
+        darkBackground: firstColor(
+            values,
+            ["dark_background", "dark_bg", "darker_background", "darker_bg"],
+            background
+        ),
+        lighterBackground: firstColor(
+            values, ["lighter_background", "lighter_bg"], background
+        ),
+        foreground: foreground,
+        muted: firstColor(
+            values, ["muted", "dark_foreground", "dark_fg"], foreground
+        ),
+        accent: firstColor(
+            values, ["accent", "blue"], rawFallback.accent
+        ),
+        red: firstColor(values, ["red"], rawFallback.red),
+        green: firstColor(values, ["green"], rawFallback.green),
+        yellow: firstColor(values, ["yellow"], rawFallback.yellow),
+        blue: firstColor(values, ["blue"], rawFallback.blue),
+        magenta: firstColor(values, ["magenta"], rawFallback.magenta),
+        cyan: firstColor(values, ["cyan"], rawFallback.cyan),
+        orange: firstColor(values, ["orange"], rawFallback.orange)
+    }
+    return semantic(raw)
+}
+
+var fallback = semantic(rawFallback)

--- a/quickshell/state/ThemePalette.js
+++ b/quickshell/state/ThemePalette.js
@@ -19,6 +19,37 @@ var rawFallback = {
     orange: "#e89562"
 }
 
+var selectableRoles = [
+    "accent",
+    "red",
+    "orange",
+    "yellow",
+    "green",
+    "cyan",
+    "blue",
+    "magenta",
+    "muted"
+]
+
+function selectableRole(value, fallbackRole) {
+    var requested = String(value || "").toLowerCase()
+    if (selectableRoles.indexOf(requested) >= 0)
+        return requested
+    return selectableRoles.indexOf(fallbackRole) >= 0
+        ? fallbackRole
+        : "accent"
+}
+
+function roleColor(theme, role, fallbackRole) {
+    var name = selectableRole(role, fallbackRole)
+    var value = theme === null || theme === undefined
+        ? undefined
+        : theme[name]
+    if (value !== undefined && value !== null && String(value) !== "")
+        return value
+    return rawFallback[selectableRole(fallbackRole, "accent")]
+}
+
 var linePattern = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"([^"]+)"/
 
 function validColor(value) {
@@ -151,7 +182,18 @@ function semantic(raw) {
         textMuted: textMuted,
         border: mixColors(raw.muted, raw.accent, 0.32),
         borderStrong: mixColors(raw.muted, raw.accent, 0.68),
-        accentSecondary: raw.cyan
+        accentSecondary: raw.cyan,
+        // Defaults for the app-level semantic roles. MappedTheme.qml replaces
+        // these aliases from persisted, allowlisted palette-role selections.
+        ready: raw.muted,
+        success: raw.green,
+        working: raw.blue,
+        needsHelp: raw.yellow,
+        reviewReady: raw.green,
+        error: raw.red,
+        unknown: raw.magenta,
+        recording: raw.green,
+        processing: raw.cyan
     })
 }
 

--- a/quickshell/tests/test_contract.py
+++ b/quickshell/tests/test_contract.py
@@ -95,6 +95,8 @@ class QmlSafetyContractTests(unittest.TestCase):
             "voice_start",
             "voice_stop",
             "voice_cancel",
+            "order_grouped",
+            "order_priority",
         ):
             self.assertIn(f'"{action}"', builder)
         self.assertIn('"type": "command"', builder)
@@ -159,7 +161,11 @@ class QmlSafetyContractTests(unittest.TestCase):
         portal = source("components/PortalView.qml")
         activity = source("state/ActivityController.qml")
         shell = source("shell.qml")
-        self.assertIn("readonly property int pageSize: 6", portal)
+        self.assertIn("readonly property int pageSize: 14", portal)
+        self.assertIn("return Math.ceil(count / 2)", portal)
+        ambient = source("components/AmbientView.qml")
+        self.assertIn("readonly property int nodeLimit: 14", ambient)
+        self.assertIn("readonly property bool denseConstellation", ambient)
         self.assertIn("ListView.Horizontal", portal)
         self.assertIn("ListView.SnapOneItem", portal)
         self.assertIn("property int inactivityMs: 60000", activity)
@@ -494,6 +500,102 @@ class QmlSafetyContractTests(unittest.TestCase):
         self.assertIn("StateDirectory=xeneon-edge-agents/portal", service)
         self.assertIn("StateDirectoryMode=0700", service)
         self.assertIn("UMask=0077", service)
+
+    def test_omarchy_theme_reload_is_runtime_owned_and_chrome_is_bound(self):
+        shell = source("shell.qml")
+        theme = source("state/OmarchyTheme.qml")
+        palette = source("state/ThemePalette.js")
+        status_palette = source("components/PortalPalette.js")
+        agent_card = source("components/AgentCard.qml")
+        ai_usage = source("components/AiUsageDock.qml")
+        ambient = source("components/AmbientView.qml")
+        display_setting = source("components/DisplaySettingButton.qml")
+        micro_drawer = source("components/MicroDrawer.qml")
+        portal = source("components/PortalView.qml")
+        voice = source("components/VoiceControl.qml")
+        qml_sources = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in ROOT.rglob("*.qml")
+            if "tests" not in path.parts
+        )
+
+        self.assertEqual(shell.count("OmarchyTheme {"), 1)
+        self.assertIn('Quickshell.env("XDG_STATE_HOME")', theme)
+        self.assertIn('/omarchy/current"', theme)
+        self.assertIn('readonly property string themeNamePath:', theme)
+        self.assertIn('readonly property string colorsPath:', theme)
+        self.assertIn("id: themeNameReader", theme)
+        self.assertIn("watchChanges: true", theme)
+        self.assertRegex(
+            theme,
+            r"onFileChanged:\s*\{\s*"
+            r"root\.requestPaletteReload\(\)\s*"
+            r"themeNameReader\.reload\(\)",
+        )
+        self.assertIn("root.requestPaletteReload()", theme)
+        self.assertIn("id: paletteReloadDebounce", theme)
+        self.assertIn('colorsReadPath = ""', theme)
+        self.assertIn(
+            "onTriggered: root.colorsReadPath = root.colorsPath",
+            theme,
+        )
+        self.assertIn("id: colorsReader", theme)
+        self.assertIn("path: root.colorsReadPath", theme)
+        self.assertIn("watchChanges: false", theme)
+        self.assertNotIn("Process {", theme)
+
+        self.assertIn("function validColor(value)", palette)
+        self.assertIn("function parse(text)", palette)
+        self.assertIn("return theme.blue", status_palette)
+        self.assertIn("return theme.yellow", status_palette)
+        self.assertIn("return theme.green", status_palette)
+        self.assertIn("return theme.red", status_palette)
+        self.assertNotRegex(status_palette, r"#[0-9A-Fa-f]{6,8}")
+        self.assertIn("String(theme.surface)", ambient)
+        self.assertNotIn("String(theme.canvas),\n        4.5", ambient)
+
+        # Omarchy owns chrome and semantic hues. State meaning remains stable
+        # through role mapping, while text variants are contrast normalized.
+        self.assertIn("accent: root.theme.green", agent_card)
+        self.assertIn("accent: root.theme.red", agent_card)
+        self.assertIn("color: root.cardBackground", agent_card)
+        self.assertIn("String(cardBackground)", agent_card)
+        self.assertIn("color: root.readablePrimary", agent_card)
+        self.assertIn("color: root.readableMuted", agent_card)
+        self.assertIn("String(statePillBackground)", agent_card)
+        self.assertIn("color: root.readablePillAccent", agent_card)
+        self.assertIn("microStatusColor: store.micro.connected", portal)
+        self.assertIn("degradedColor: theme.yellow", portal)
+        self.assertIn("toastColor: toastSuccess", portal)
+        self.assertIn("border.color: root.theme.red", voice)
+        self.assertIn("String(controlBackground)", voice)
+        self.assertIn("color: root.readableSecondary", voice)
+        self.assertIn("root.readableColor(accent)", ai_usage)
+        self.assertIn("root.readableColor(\n                            root.statusColor", ai_usage)
+        self.assertIn("ThemePalette.ensureContrast(", display_setting)
+        self.assertIn("color: root.readableConnectionColor", micro_drawer)
+        self.assertIn("color: root.readableSurfaceMessageColor", portal)
+
+        self.assertNotIn(
+            "color: providerAvailable ? accent", ai_usage
+        )
+        self.assertNotIn(
+            "color: root.checked ? root.accent : root.theme.textMuted\n"
+            "                font {",
+            display_setting,
+        )
+        self.assertNotIn("? root.theme.green", micro_drawer)
+        self.assertNotIn("? root.theme.red", micro_drawer)
+        self.assertIn("return root.theme.muted", micro_drawer)
+        self.assertIn('? theme.muted\n        : Palette.ambientColor', ambient)
+
+        # The only literal left in production QML is the intentional black
+        # minimum-screen veil. Theme defaults live in the reviewed palette JS;
+        # state color meaning maps onto those runtime theme roles.
+        self.assertEqual(
+            set(re.findall(r"#[0-9A-Fa-f]{6,8}", qml_sources)),
+            {"#000000"},
+        )
 
 
 if __name__ == "__main__":

--- a/quickshell/tests/test_contract.py
+++ b/quickshell/tests/test_contract.py
@@ -444,6 +444,7 @@ class QmlSafetyContractTests(unittest.TestCase):
         shell = source("shell.qml")
         portal = source("components/PortalView.qml")
         controls = source("components/DisplaySettingsControls.qml")
+        palette_pane = source("components/PaletteSettingsPane.qml")
         button = source("components/DisplaySettingButton.qml")
         ring = source("components/AmbientRing.qml")
         service = (ROOT.parent / "config/systemd/user/"
@@ -462,9 +463,21 @@ class QmlSafetyContractTests(unittest.TestCase):
         self.assertIn('category: "display"', shell)
         self.assertIn("property bool reduceMotion: false", shell)
         self.assertIn("property bool dimmed: false", shell)
+        for setting in (
+            'readyColorRole: "muted"',
+            'successColorRole: "green"',
+            'workingColorRole: "blue"',
+            'needsHelpColorRole: "yellow"',
+            'reviewReadyColorRole: "green"',
+            'errorColorRole: "red"',
+            'unknownColorRole: "magenta"',
+            'recordingColorRole: "green"',
+            'processingColorRole: "cyan"',
+        ):
+            self.assertIn(setting, shell)
         self.assertEqual(
             shell.count("preferences: portalPreferences"),
-            2,
+            3,
         )
 
         self.assertEqual(portal.count("DisplaySettingsControls {"), 1)
@@ -483,12 +496,14 @@ class QmlSafetyContractTests(unittest.TestCase):
 
         self.assertIn('label: "MOTION"', controls)
         self.assertIn('label: "SCREEN"', controls)
+        self.assertIn('label: "PALETTE"', controls)
         self.assertIn('stateLabel: root.dimmed ? "MINIMUM" : "NORMAL"', controls)
         self.assertIn("Accessible.role: Accessible.Button", button)
         self.assertIn("TapHandler.ReleaseWithinBounds", button)
         self.assertIn("property bool suppressRunners: false", ring)
         self.assertIn('mode !== "off" && !suppressRunners', ring)
         self.assertNotIn("Process {", controls)
+        self.assertNotIn("Process {", palette_pane)
         self.assertNotIn("Process {", button)
         self.assertEqual(len(re.findall(r"\bProcess\s*\{", qml)), 1)
 
@@ -505,7 +520,9 @@ class QmlSafetyContractTests(unittest.TestCase):
         shell = source("shell.qml")
         theme = source("state/OmarchyTheme.qml")
         palette = source("state/ThemePalette.js")
+        mapped_theme = source("state/MappedTheme.qml")
         status_palette = source("components/PortalPalette.js")
+        palette_pane = source("components/PaletteSettingsPane.qml")
         agent_card = source("components/AgentCard.qml")
         ai_usage = source("components/AiUsageDock.qml")
         ambient = source("components/AmbientView.qml")
@@ -520,6 +537,7 @@ class QmlSafetyContractTests(unittest.TestCase):
         )
 
         self.assertEqual(shell.count("OmarchyTheme {"), 1)
+        self.assertEqual(shell.count("MappedTheme {"), 1)
         self.assertIn('Quickshell.env("XDG_STATE_HOME")', theme)
         self.assertIn('/omarchy/current"', theme)
         self.assertIn('readonly property string themeNamePath:', theme)
@@ -546,18 +564,34 @@ class QmlSafetyContractTests(unittest.TestCase):
 
         self.assertIn("function validColor(value)", palette)
         self.assertIn("function parse(text)", palette)
-        self.assertIn("return theme.blue", status_palette)
-        self.assertIn("return theme.yellow", status_palette)
-        self.assertIn("return theme.green", status_palette)
-        self.assertIn("return theme.red", status_palette)
+        self.assertIn("function selectableRole(value, fallbackRole)", palette)
+        self.assertIn("function roleColor(theme, role, fallbackRole)", palette)
+        for role in (
+            "theme.working",
+            "theme.needsHelp",
+            "theme.reviewReady",
+            "theme.error",
+            "theme.ready",
+            "theme.unknown",
+            "theme.recording",
+            "theme.processing",
+        ):
+            self.assertIn(role, status_palette)
         self.assertNotRegex(status_palette, r"#[0-9A-Fa-f]{6,8}")
         self.assertIn("String(theme.surface)", ambient)
         self.assertNotIn("String(theme.canvas),\n        4.5", ambient)
 
-        # Omarchy owns chrome and semantic hues. State meaning remains stable
-        # through role mapping, while text variants are contrast normalized.
-        self.assertIn("accent: root.theme.green", agent_card)
-        self.assertIn("accent: root.theme.red", agent_card)
+        # Omarchy owns the source hues. XENEON persists only allowlisted role
+        # names and maps explicit app meanings while text remains normalized.
+        self.assertIn('mappedColor("workingColorRole", "blue")', mapped_theme)
+        self.assertIn('mappedColor("successColorRole", "green")', mapped_theme)
+        self.assertIn('mappedColor("needsHelpColorRole", "yellow")', mapped_theme)
+        self.assertIn('mappedColor("reviewReadyColorRole", "green")', mapped_theme)
+        self.assertIn('mappedColor("errorColorRole", "red")', mapped_theme)
+        self.assertIn("ThemePalette.selectableRoles.indexOf(role) < 0", palette_pane)
+        self.assertNotIn("property color", palette_pane)
+        self.assertIn("accent: root.theme.reviewReady", agent_card)
+        self.assertIn("accent: root.theme.error", agent_card)
         self.assertIn("color: root.cardBackground", agent_card)
         self.assertIn("String(cardBackground)", agent_card)
         self.assertIn("color: root.readablePrimary", agent_card)
@@ -565,9 +599,10 @@ class QmlSafetyContractTests(unittest.TestCase):
         self.assertIn("String(statePillBackground)", agent_card)
         self.assertIn("color: root.readablePillAccent", agent_card)
         self.assertIn("microStatusColor: store.micro.connected", portal)
-        self.assertIn("degradedColor: theme.yellow", portal)
+        self.assertIn("? theme.success\n        : theme.error", portal)
+        self.assertIn("degradedColor: theme.needsHelp", portal)
         self.assertIn("toastColor: toastSuccess", portal)
-        self.assertIn("border.color: root.theme.red", voice)
+        self.assertIn("border.color: root.theme.error", voice)
         self.assertIn("String(controlBackground)", voice)
         self.assertIn("color: root.readableSecondary", voice)
         self.assertIn("root.readableColor(accent)", ai_usage)
@@ -586,8 +621,9 @@ class QmlSafetyContractTests(unittest.TestCase):
         )
         self.assertNotIn("? root.theme.green", micro_drawer)
         self.assertNotIn("? root.theme.red", micro_drawer)
-        self.assertIn("return root.theme.muted", micro_drawer)
-        self.assertIn('? theme.muted\n        : Palette.ambientColor', ambient)
+        self.assertIn("? theme.success\n        : theme.error", micro_drawer)
+        self.assertIn("return root.theme.ready", micro_drawer)
+        self.assertIn('? theme.ready\n        : Palette.ambientColor', ambient)
 
         # The only literal left in production QML is the intentional black
         # minimum-screen veil. Theme defaults live in the reviewed palette JS;

--- a/quickshell/tests/tst_ai_usage.qml
+++ b/quickshell/tests/tst_ai_usage.qml
@@ -33,12 +33,12 @@ TestCase {
                 "source": "oauth",
                 "status": "allowed_warning",
                 "primary": {
-                    "label": "5h",
+                    "label": "Session (5-hour)",
                     "utilization": 0.03,
                     "reset_at_ms": Date.now() + 7200000
                 },
                 "secondary": {
-                    "label": "Weekly",
+                    "label": "Weekly (7-day)",
                     "utilization": 0.07,
                     "reset_at_ms": Date.now() + 604800000
                 },
@@ -53,7 +53,7 @@ TestCase {
                 "status": "allowed",
                 "plan": "pro",
                 "primary": {
-                    "label": "Weekly",
+                    "label": "Weekly (7-day)",
                     "utilization": 0.74,
                     "reset_at_ms": Date.now() + 86400000
                 },
@@ -102,6 +102,9 @@ TestCase {
         )
         compare(opencode.statusLabel, "STALE")
         compare(opencode.activityLabel, "GPT-5.6-SOL (OPENAI)")
+        verify(!findChild(dock, "usageLabel_claude_primary").truncated)
+        verify(!findChild(dock, "usageLabel_claude_secondary").truncated)
+        verify(!findChild(dock, "usageLabel_codex_primary").truncated)
     }
 
     function test_statusAndFormattingStayBoundedAndExplicit() {

--- a/quickshell/tests/tst_ambient.qml
+++ b/quickshell/tests/tst_ambient.qml
@@ -195,7 +195,10 @@ TestCase {
 
     function test_reviewReadyUsesExactPaletteAndPlainText() {
         compare(reviewNode.agentState, "review")
-        compare(String(reviewNode.accent), String(reviewNode.theme.green))
+        compare(
+            String(reviewNode.accent),
+            String(reviewNode.theme.reviewReady)
+        )
 
         var label = findChild(reviewNode, "ambientAgentDisplayName")
         verify(label !== null)

--- a/quickshell/tests/tst_ambient.qml
+++ b/quickshell/tests/tst_ambient.qml
@@ -67,6 +67,13 @@ TestCase {
         return result
     }
 
+    function fourteenAgents() {
+        var result = []
+        for (var index = 0; index < 14; index += 1)
+            result.push(agent(index))
+        return result
+    }
+
     function init() {
         ambient.reducedMotion = true
         ambient.active = false
@@ -87,16 +94,108 @@ TestCase {
         tryCompare(ambient, "revealProgress", 0)
     }
 
-    function test_capsConstellationAtSixAgents() {
-        compare(ambient.nodeLimit, 6)
-        compare(ambient.visibleAgentCount, 6)
-        verify(findChild(ambient, "ambientAgentNode-5") !== null)
-        compare(findChild(ambient, "ambientAgentNode-6"), null)
+    function verifyNodeBounds(count, reduced, phase, boostPhase) {
+        ambient.agents = fourteenAgents().concat([
+            agent(14), agent(15), agent(16), agent(17), agent(18)
+        ]).slice(0, count)
+        ambient.reducedMotion = reduced
+        ambient.orbitPhase = phase
+        ambient.orbitBoostPhase = boostPhase === undefined ? phase / 2 : boostPhase
+        ambient.motionEnergy = reduced ? 0 : 1
+        wait(0)
+        var constellation = findChild(ambient, "ambientConstellation")
+        verify(constellation !== null)
+        var visible = Math.min(14, count)
+        for (var firstIndex = 0; firstIndex < visible; firstIndex += 1) {
+            var first = findChild(ambient, "ambientAgentNode-" + firstIndex)
+            verify(first !== null)
+            var halo = first.dense ? 8 : 12
+            verify(first.x - halo >= -0.5)
+            verify(first.y - halo >= -0.5)
+            verify(
+                first.x + first.width + halo
+                    <= constellation.width + 0.5
+            )
+            verify(
+                first.y + first.height + halo
+                    <= constellation.height + 0.5
+            )
+        }
+    }
+
+    function test_capsConstellationAtFourteenIndependentLanes() {
+        ambient.agents = fourteenAgents().concat([agent(14)])
+        ambient.reducedMotion = false
+        compare(ambient.nodeLimit, 14)
+        compare(ambient.visibleAgentCount, 14)
+        compare(ambient.denseConstellation, true)
+        verify(findChild(ambient, "ambientAgentNode-13") !== null)
+        compare(findChild(ambient, "ambientAgentNode-14"), null)
+        compare(ambient.radiusXFor(0), 720)
+        compare(ambient.radiusXFor(7), 680)
+        compare(ambient.radiusYFor(0), 190)
+        compare(ambient.radiusYFor(7), 200)
+        var denseSpeeds = [1, 2, 1, 3, 2, 1, 2, 3, 1, 2, 3, 1, 2, 3]
+        var denseRadiiX = [
+            720, 800, 660, 780, 700, 820, 750,
+            680, 810, 730, 770, 650, 790, 710
+        ]
+        var denseRadiiY = [
+            190, 230, 205, 242, 215, 185, 235,
+            200, 225, 195, 240, 210, 180, 220
+        ]
+        for (var lane = 0; lane < 14; lane += 1) {
+            compare(ambient.speedFor(lane), denseSpeeds[lane])
+            compare(ambient.radiusXFor(lane), denseRadiiX[lane])
+            compare(ambient.radiusYFor(lane), denseRadiiY[lane])
+        }
+
+        var constellation = findChild(ambient, "ambientConstellation")
+        verify(constellation !== null)
+        for (var index = 0; index < 14; index += 1) {
+            var node = findChild(ambient, "ambientAgentNode-" + index)
+            verify(node !== null)
+            verify(node.x >= -0.5)
+            verify(node.y >= -0.5)
+            verify(node.x + node.width <= constellation.width + 0.5)
+            verify(node.y + node.height <= constellation.height + 0.5)
+        }
+    }
+
+    function test_constellationStaysBoundedAcrossCountsAndPhases() {
+        var phases = [0, 0.071, 0.125, 0.2143, 0.333, 0.5, 0.875]
+        for (var sparseCount = 1; sparseCount <= 6; sparseCount += 1) {
+            verifyNodeBounds(sparseCount, true, 0)
+            for (var sparsePhase = 0;
+                    sparsePhase < phases.length; sparsePhase += 1) {
+                verifyNodeBounds(
+                    sparseCount,
+                    false,
+                    phases[sparsePhase],
+                    phases[(sparsePhase + 2) % phases.length]
+                )
+            }
+        }
+        for (var count = 7; count <= 14; count += 1) {
+            verifyNodeBounds(count, true, 0)
+            for (var phaseIndex = 0;
+                    phaseIndex < phases.length; phaseIndex += 1) {
+                verifyNodeBounds(count, false, phases[phaseIndex])
+                verifyNodeBounds(
+                    count,
+                    false,
+                    phases[phaseIndex],
+                    phases[(phaseIndex + 3) % phases.length]
+                )
+            }
+        }
+        verifyNodeBounds(19, true, 0)
+        verifyNodeBounds(19, false, 0.2143)
     }
 
     function test_reviewReadyUsesExactPaletteAndPlainText() {
         compare(reviewNode.agentState, "review")
-        compare(String(reviewNode.accent), "#00ff00")
+        compare(String(reviewNode.accent), String(reviewNode.theme.green))
 
         var label = findChild(reviewNode, "ambientAgentDisplayName")
         verify(label !== null)
@@ -111,7 +210,7 @@ TestCase {
             "owned": true
         }
         compare(ambient.mode, "voice-recording")
-        compare(String(ambient.modeAccent), "#2e8b57")
+        compare(String(ambient.modeAccent), String(ambient.theme.green))
         compare(ambient.centerTitle(), "VOICE")
         compare(ambient.centerDetail(), "VOICE // RECORDING")
 
@@ -122,23 +221,55 @@ TestCase {
         }
         ambient.connectionState = "offline"
         compare(ambient.mode, "error")
-        compare(String(ambient.modeAccent), "#ff2020")
+        compare(String(ambient.modeAccent), String(ambient.theme.red))
         compare(ambient.centerTitle(), "ATTENTION")
     }
 
-    function test_nodesMoveClockwiseAtIndependentRates() {
+    function test_denseNodesUseIndependentLegacyStyleLanes() {
+        ambient.agents = fourteenAgents()
         ambient.reducedMotion = false
         ambient.orbitPhase = 0
         var firstStart = ambient.nodeAngleDegrees(0)
         var secondStart = ambient.nodeAngleDegrees(1)
 
-        ambient.orbitPhase = 0.25
+        ambient.orbitPhase = 0.125
         var firstDelta = ambient.nodeAngleDegrees(0) - firstStart
         var secondDelta = ambient.nodeAngleDegrees(1) - secondStart
 
         verify(firstDelta > 0)
         verify(secondDelta > 0)
-        verify(Math.abs(firstDelta - secondDelta) > 1)
+        verify(secondDelta > firstDelta)
+        compare(ambient.speedFor(0), 1)
+        compare(ambient.speedFor(1), 2)
+        compare(ambient.speedFor(3), 3)
+        verify(ambient.radiusXFor(0) !== ambient.radiusXFor(7))
+    }
+
+    function test_sixAgentMotionRestoresExactIndependentOriginalLanes() {
+        ambient.agents = sevenAgents().slice(0, 6)
+        ambient.reducedMotion = false
+        ambient.orbitPhase = 0
+        compare(ambient.denseConstellation, false)
+        var speeds = [1, 2, 1, 3, 2, 1]
+        var angles = [-88, -30, 30, 92, 154, 214]
+        var radiiX = [410, 530, 650, 470, 600, 510]
+        var radiiY = [152, 205, 174, 238, 214, 188]
+        for (var index = 0; index < 6; index += 1) {
+            compare(ambient.speedFor(index), speeds[index])
+            compare(ambient.baseAngleFor(index), angles[index])
+            compare(ambient.radiusXFor(index), radiiX[index])
+            compare(ambient.radiusYFor(index), radiiY[index])
+        }
+
+        var firstStart = ambient.nodeAngleDegrees(0)
+        var secondStart = ambient.nodeAngleDegrees(1)
+        ambient.orbitPhase = 0.125
+        verify(ambient.nodeAngleDegrees(0) > firstStart)
+        verify(ambient.nodeAngleDegrees(1) > secondStart)
+        verify(
+            ambient.nodeAngleDegrees(1) - secondStart
+                > ambient.nodeAngleDegrees(0) - firstStart
+        )
     }
 
     function test_reducedMotionEvenlySpacesStaticAgents() {
@@ -159,6 +290,8 @@ TestCase {
     }
 
     function test_phaseWrapsAreGeometricallyContinuous() {
+        ambient.agents = sevenAgents().slice(0, 6)
+        ambient.reducedMotion = false
         ambient.motionEnergy = 0
         ambient.orbitPhase = 1
         var quietEnd = normalizedAngle(ambient.nodeAngleDegrees(1))
@@ -172,6 +305,19 @@ TestCase {
         ambient.orbitBoostPhase = 0
         var boostStart = normalizedAngle(ambient.nodeAngleDegrees(3))
         fuzzyCompare(boostEnd, boostStart, 0.0001)
+
+        ambient.agents = fourteenAgents()
+        ambient.orbitPhase = 1
+        var denseOrbitEnd = normalizedAngle(ambient.nodeAngleDegrees(13))
+        ambient.orbitPhase = 0
+        var denseOrbitStart = normalizedAngle(ambient.nodeAngleDegrees(13))
+        fuzzyCompare(denseOrbitEnd, denseOrbitStart, 0.0001)
+
+        ambient.orbitBoostPhase = 1
+        var denseBoostEnd = normalizedAngle(ambient.nodeAngleDegrees(10))
+        ambient.orbitBoostPhase = 0
+        var denseBoostStart = normalizedAngle(ambient.nodeAngleDegrees(10))
+        fuzzyCompare(denseBoostEnd, denseBoostStart, 0.0001)
     }
 
     function test_reducedMotionUsesFinalStaticComposition() {

--- a/quickshell/tests/tst_command.qml
+++ b/quickshell/tests/tst_command.qml
@@ -103,6 +103,18 @@ TestCase {
         }
     }
 
+    function test_orderActionsAreTypedAndCannotTargetAgents() {
+        for (var index = 0; index < 2; index += 1) {
+            var action = ["order_grouped", "order_priority"][index]
+            var command = builder.build(action, "", "", 46)
+            verify(command !== null)
+            compare(command.action, action)
+            compare(command.agent_id, undefined)
+            compare(command.capability_id, undefined)
+            compare(builder.build(action, "agent-1", "", 46), null)
+        }
+    }
+
     function test_rejectsRawOrUnknownActions() {
         compare(builder.build("send_keys", "agent-1", "", 42), null)
         compare(builder.build("shell", "agent-1", "", 42), null)

--- a/quickshell/tests/tst_display_settings.qml
+++ b/quickshell/tests/tst_display_settings.qml
@@ -25,24 +25,37 @@ TestCase {
         signalName: "dimToggleRequested"
     }
 
+    SignalSpy {
+        id: paletteSpy
+        target: settings
+        signalName: "paletteToggleRequested"
+    }
+
     function init() {
         settings.motionReduced = false
         settings.motionForced = false
         settings.dimmed = false
+        settings.paletteOpen = false
+        settings.paletteCustom = false
         motionSpy.clear()
         dimSpy.clear()
+        paletteSpy.clear()
     }
 
     function test_buttonsExposeCurrentGlobalState() {
         var motion = findChild(settings, "motionSettingButton")
         var dim = findChild(settings, "dimSettingButton")
+        var palette = findChild(settings, "paletteSettingButton")
 
         verify(motion !== null)
         verify(dim !== null)
+        verify(palette !== null)
         compare(motion.checked, false)
         compare(motion.stateLabel, "FULL")
         compare(dim.checked, false)
         compare(dim.stateLabel, "NORMAL")
+        compare(palette.checked, false)
+        compare(palette.stateLabel, "THEME")
 
         settings.motionReduced = true
         settings.dimmed = true
@@ -50,11 +63,17 @@ TestCase {
         compare(motion.stateLabel, "REDUCED")
         compare(dim.checked, true)
         compare(dim.stateLabel, "MINIMUM")
+        settings.paletteCustom = true
+        compare(palette.checked, true)
+        compare(palette.stateLabel, "CUSTOM")
+        settings.paletteOpen = true
+        compare(palette.stateLabel, "OPEN")
     }
 
     function test_activationRequestsExactlyOneToggle() {
         var motion = findChild(settings, "motionSettingButton")
         var dim = findChild(settings, "dimSettingButton")
+        var palette = findChild(settings, "paletteSettingButton")
 
         compare(motion.activate(), true)
         compare(motionSpy.count, 1)
@@ -63,6 +82,9 @@ TestCase {
         compare(dim.activate(), true)
         compare(motionSpy.count, 1)
         compare(dimSpy.count, 1)
+
+        compare(palette.activate(), true)
+        compare(paletteSpy.count, 1)
     }
 
     function test_systemReducedMotionCannotBeReenabled() {

--- a/quickshell/tests/tst_interaction.qml
+++ b/quickshell/tests/tst_interaction.qml
@@ -219,6 +219,15 @@ TestCase {
     function test_agentCardUsesAuthoritativeStateAgeWithoutGenericSummary() {
         compare(hostileCard.processLine(), "WORKING  ·  1S IN STATE")
         compare(hostileCard.contextLine(), "<b>workspace</b>")
+        compare(hostileCard.spaceLine(), "SPACE // <b>workspace</b>")
+        var spaceName = findChild(hostileCard, "agentSpaceName")
+        verify(spaceName !== null)
+        compare(spaceName.textFormat, Text.PlainText)
+        verify(
+            hostileCard.Accessible.description.indexOf(
+                "SPACE // <b>workspace</b>"
+            ) >= 0
+        )
     }
 
     function test_agentCardHasOneWholeCardFocusAction() {

--- a/quickshell/tests/tst_palette.qml
+++ b/quickshell/tests/tst_palette.qml
@@ -6,6 +6,19 @@ import "../components/PortalPalette.js" as Palette
 TestCase {
     name: "PortalPalette"
 
+    property var semanticTheme: ({
+        "blue": "#123456",
+        "yellow": "#654321",
+        "green": "#246813",
+        "red": "#975310",
+        "magenta": "#864209",
+        "cyan": "#135724",
+        "muted": "#555555",
+        "border": "#333333",
+        "surface": "#111111",
+        "textPrimary": "#eeeeee"
+    })
+
     AmbientRing {
         id: halo
 
@@ -14,6 +27,7 @@ TestCase {
         reducedMotion: true
         connectionState: "connected"
         voice: ({"state": "idle"})
+        theme: semanticTheme
     }
 
     function agent(status, reviewReady) {
@@ -33,13 +47,46 @@ TestCase {
         halo.agents = []
     }
 
-    function test_microAgentPaletteIsExact() {
-        compare(String(Palette.agentColor(agent("working"))), "#0066ff")
-        compare(String(Palette.agentColor(agent("blocked"))), "#ffaa00")
-        compare(String(Palette.agentColor(agent("done", true))), "#00ff00")
-        compare(String(Palette.agentColor(agent("done", false))), "#303030")
-        compare(String(Palette.agentColor(agent("idle"))), "#303030")
-        compare(String(Palette.agentColor(agent("unknown"))), "#300840")
+    function test_agentColorsFollowThemeSemanticRoles() {
+        compare(
+            String(Palette.agentColor(agent("working"), semanticTheme)),
+            semanticTheme.blue
+        )
+        compare(
+            String(Palette.agentColor(agent("blocked"), semanticTheme)),
+            semanticTheme.yellow
+        )
+        compare(
+            String(Palette.agentColor(agent("done", true), semanticTheme)),
+            semanticTheme.green
+        )
+        compare(
+            String(Palette.agentColor(agent("done", false), semanticTheme)),
+            semanticTheme.muted
+        )
+        compare(
+            String(Palette.agentColor(agent("unknown"), semanticTheme)),
+            semanticTheme.magenta
+        )
+    }
+
+    function test_ambientColorsFollowThemeSemanticRoles() {
+        compare(Palette.ambientColor("working", semanticTheme), semanticTheme.blue)
+        compare(Palette.ambientColor("blocked", semanticTheme), semanticTheme.yellow)
+        compare(Palette.ambientColor("review", semanticTheme), semanticTheme.green)
+        compare(Palette.ambientColor("error", semanticTheme), semanticTheme.red)
+        compare(
+            Palette.ambientColor("voice-processing", semanticTheme),
+            semanticTheme.cyan
+        )
+        compare(
+            Palette.ambientColor("voice-recording", semanticTheme),
+            semanticTheme.green
+        )
+        compare(
+            Palette.ambientColor("off", semanticTheme),
+            semanticTheme.muted
+        )
     }
 
     function test_reviewReadyOverridesIdleButNotActiveAttention() {

--- a/quickshell/tests/tst_palette.qml
+++ b/quickshell/tests/tst_palette.qml
@@ -14,6 +14,15 @@ TestCase {
         "magenta": "#864209",
         "cyan": "#135724",
         "muted": "#555555",
+        "working": "#112233",
+        "needsHelp": "#332211",
+        "reviewReady": "#224422",
+        "error": "#442222",
+        "unknown": "#442244",
+        "ready": "#444444",
+        "success": "#225522",
+        "recording": "#225533",
+        "processing": "#224455",
         "border": "#333333",
         "surface": "#111111",
         "textPrimary": "#eeeeee"
@@ -50,42 +59,54 @@ TestCase {
     function test_agentColorsFollowThemeSemanticRoles() {
         compare(
             String(Palette.agentColor(agent("working"), semanticTheme)),
-            semanticTheme.blue
+            semanticTheme.working
         )
         compare(
             String(Palette.agentColor(agent("blocked"), semanticTheme)),
-            semanticTheme.yellow
+            semanticTheme.needsHelp
         )
         compare(
             String(Palette.agentColor(agent("done", true), semanticTheme)),
-            semanticTheme.green
+            semanticTheme.reviewReady
         )
         compare(
             String(Palette.agentColor(agent("done", false), semanticTheme)),
-            semanticTheme.muted
+            semanticTheme.ready
         )
         compare(
             String(Palette.agentColor(agent("unknown"), semanticTheme)),
-            semanticTheme.magenta
+            semanticTheme.unknown
         )
     }
 
     function test_ambientColorsFollowThemeSemanticRoles() {
-        compare(Palette.ambientColor("working", semanticTheme), semanticTheme.blue)
-        compare(Palette.ambientColor("blocked", semanticTheme), semanticTheme.yellow)
-        compare(Palette.ambientColor("review", semanticTheme), semanticTheme.green)
-        compare(Palette.ambientColor("error", semanticTheme), semanticTheme.red)
+        compare(
+            Palette.ambientColor("working", semanticTheme),
+            semanticTheme.working
+        )
+        compare(
+            Palette.ambientColor("blocked", semanticTheme),
+            semanticTheme.needsHelp
+        )
+        compare(
+            Palette.ambientColor("review", semanticTheme),
+            semanticTheme.reviewReady
+        )
+        compare(
+            Palette.ambientColor("error", semanticTheme),
+            semanticTheme.error
+        )
         compare(
             Palette.ambientColor("voice-processing", semanticTheme),
-            semanticTheme.cyan
+            semanticTheme.processing
         )
         compare(
             Palette.ambientColor("voice-recording", semanticTheme),
-            semanticTheme.green
+            semanticTheme.recording
         )
         compare(
             Palette.ambientColor("off", semanticTheme),
-            semanticTheme.muted
+            semanticTheme.ready
         )
     }
 

--- a/quickshell/tests/tst_portal_layout.qml
+++ b/quickshell/tests/tst_portal_layout.qml
@@ -1,0 +1,248 @@
+import QtQuick
+import QtTest
+import "../components"
+import "../state/ThemePalette.js" as ThemePalette
+
+TestCase {
+    id: testCase
+
+    name: "PortalLayout"
+    width: 2560
+    height: 720
+
+    QtObject {
+        id: mockStore
+
+        signal actionResultReceived(var result)
+        signal noticeReceived(var notice)
+
+        property var agents: []
+        property var agentOrder: ({"available": true, "mode": "grouped"})
+        property var sessions: []
+        property var usage: ({"providers": []})
+        property var micro: ({"connected": false, "charging": false})
+        property var voice: ({"available": false, "state": "unavailable"})
+        property var health: ({})
+        property var connection: ({"state": "connected", "detail": ""})
+        property string transportDetail: ""
+        property string protocolError: ""
+        property bool freshSnapshotRequired: false
+        property double sequence: 1
+        property string testSurfaceState: ""
+
+        function surfaceState() {
+            return testSurfaceState || (agents.length > 0 ? "ready" : "empty")
+        }
+    }
+
+    QtObject {
+        id: mockBridge
+
+        signal commandRejected(string reason)
+        signal commandEmitted(var command)
+
+        property bool ready: true
+        property int orderRequests: 0
+        property string lastOrder: ""
+
+        function restoreFocus() { return "restore" }
+        function openAgent(agentId) { return agentId }
+        function approveAgent() { return "approve" }
+        function interruptAgent() { return "interrupt" }
+        function openChatGptDesktop() { return "chatgpt" }
+        function openClaudeDesktop() { return "claude" }
+        function startVoice() { return "voice-start" }
+        function stopVoice() { return "voice-stop" }
+        function cancelVoice() { return "voice-cancel" }
+        function setAgentOrder(mode) {
+            orderRequests += 1
+            lastOrder = mode
+            return "order-" + orderRequests
+        }
+    }
+
+    QtObject {
+        id: mockActivity
+
+        property bool ambientMode: false
+        function noteUserActivity() {}
+    }
+
+    QtObject {
+        id: mockPreferences
+
+        property bool reduceMotion: false
+        property bool dimmed: false
+        function sync() {}
+    }
+
+    PortalView {
+        id: portal
+
+        width: testCase.width
+        height: testCase.height
+        store: mockStore
+        bridge: mockBridge
+        activity: mockActivity
+        preferences: mockPreferences
+        theme: ThemePalette.fallback
+        reducedMotion: true
+    }
+
+    function agent(index) {
+        return {
+            "id": "layout-agent-" + index,
+            "display_name": "Layout Agent " + index,
+            "agent": "fixture",
+            "status": index % 3 === 0 ? "working" : "idle",
+            "review_ready": false,
+            "focused": index === 0,
+            "observed_for_seconds": index,
+            "workspace": "layout-test",
+            "repository": "xeneon-edge-agents",
+            "worktree": "",
+            "actions": {
+                "open": true,
+                "zoom": true,
+                "approve": null,
+                "interrupt": null
+            }
+        }
+    }
+
+    function agents(count) {
+        var result = []
+        for (var index = 0; index < count; index += 1)
+            result.push(agent(index))
+        return result
+    }
+
+    function init() {
+        mockStore.agents = agents(20)
+        mockStore.agentOrder = {"available": true, "mode": "grouped"}
+        mockStore.connection = {"state": "connected", "detail": ""}
+        mockStore.testSurfaceState = ""
+        mockBridge.orderRequests = 0
+        mockBridge.lastOrder = ""
+        portal.pendingAgentOrderRequest = ""
+        portal.currentPage = 0
+        wait(0)
+    }
+
+    function cleanup() {
+        mockStore.agents = []
+        portal.currentPage = 0
+        wait(0)
+    }
+
+    function test_twentyAgentsUseFourteenPlusSixPages() {
+        compare(portal.pageSize, 14)
+        compare(portal.pageCount, 2)
+        compare(portal.pageAgentCount(0), 14)
+        compare(portal.pageColumns(0), 7)
+        compare(portal.pageRows(0), 2)
+        compare(portal.pageAgentCount(1), 6)
+        compare(portal.pageColumns(1), 3)
+        compare(portal.pageRows(1), 2)
+        compare(portal.agentAt(0, 13).id, "layout-agent-13")
+        compare(portal.agentAt(1, 0).id, "layout-agent-14")
+        compare(portal.agentAt(1, 5).id, "layout-agent-19")
+        compare(portal.agentAt(1, 6), null)
+
+        var firstGrid = findChild(portal, "agentGrid_0")
+        var firstLastCard = findChild(portal, "agentCard_0_13")
+        var firstSpaceName = findChild(firstLastCard, "agentSpaceName")
+        verify(firstGrid !== null)
+        verify(firstLastCard !== null)
+        verify(firstSpaceName !== null)
+        compare(firstGrid.columns, 7)
+        compare(firstSpaceName.text, "SPACE // LAYOUT-TEST")
+        verify(!firstSpaceName.truncated)
+        verify(firstLastCard.width > 330)
+        verify(firstLastCard.height > 220)
+        verify(firstLastCard.x + firstLastCard.width <= firstGrid.width + 0.5)
+        verify(firstLastCard.y + firstLastCard.height <= firstGrid.height + 0.5)
+
+        portal.selectPage(1)
+        tryCompare(portal, "currentPage", 1)
+        var pages = findChild(portal, "agentPages")
+        tryCompare(pages, "currentIndex", 1)
+        var secondGrid = findChild(portal, "agentGrid_1")
+        var secondLastCard = findChild(portal, "agentCard_1_5")
+        verify(secondGrid !== null)
+        verify(secondLastCard !== null)
+        compare(secondGrid.columns, 3)
+        verify(secondLastCard.x + secondLastCard.width <= secondGrid.width + 0.5)
+        verify(secondLastCard.y + secondLastCard.height <= secondGrid.height + 0.5)
+    }
+
+    function test_agentOrderToggleUsesAuthoritativeHerdrModeOnce() {
+        var toggle = findChild(portal, "agentOrderToggle")
+        var label = findChild(portal, "agentOrderLabel")
+        verify(toggle !== null)
+        verify(label !== null)
+        verify(toggle.enabled)
+        compare(label.text, "ORDER // GROUPED")
+
+        verify(toggle.activate())
+        compare(mockBridge.orderRequests, 1)
+        compare(mockBridge.lastOrder, "priority")
+        verify(!toggle.enabled)
+        compare(label.text, "ORDER // SYNCING")
+        compare(toggle.Accessible.name, "Agent ordering syncing")
+        compare(
+            toggle.Accessible.description,
+            "Synchronizing agent ordering with Herdr"
+        )
+
+        mockStore.actionResultReceived({
+            "request_id": "order-1",
+            "action": "order_priority",
+            "ok": true,
+            "code": "agent_order_updated",
+            "message": "agent_order_updated"
+        })
+        compare(portal.pendingAgentOrderRequest, "")
+        mockStore.agentOrder = {"available": true, "mode": "priority"}
+        compare(label.text, "ORDER // PRIORITY")
+        verify(toggle.activate())
+        compare(mockBridge.orderRequests, 2)
+        compare(mockBridge.lastOrder, "grouped")
+    }
+
+    function test_lowerCountsAndShrinkClampSafely() {
+        mockStore.agents = agents(4)
+        wait(0)
+        compare(portal.pageCount, 1)
+        compare(portal.pageColumns(0), 2)
+        compare(portal.pageRows(0), 2)
+
+        mockStore.agents = agents(20)
+        wait(0)
+        portal.selectPage(1)
+        tryCompare(portal, "currentPage", 1)
+        mockStore.agents = agents(6)
+        tryCompare(portal, "pageCount", 1)
+        tryCompare(portal, "currentPage", 0)
+        compare(portal.pageColumns(0), 3)
+        compare(portal.pageRows(0), 2)
+    }
+
+    function test_degradedBannerRendersBoundedProtocolReasonAsPlainText() {
+        var prefix = "Herdr protocol 19 is incompatible <img src='file:///private'> "
+        var reason = prefix + "X".repeat(160 - prefix.length)
+        compare(reason.length, 160)
+        mockStore.connection = {"state": "degraded", "detail": reason}
+        mockStore.testSurfaceState = "degraded"
+        tryCompare(portal, "surfaceState", "degraded")
+
+        var banner = findChild(portal, "degradedBanner")
+        var label = findChild(portal, "degradedBannerText")
+        verify(banner !== null)
+        verify(label !== null)
+        tryCompare(banner, "height", 28)
+        compare(label.text, "DEGRADED // " + reason.toUpperCase())
+        compare(label.textFormat, Text.PlainText)
+        verify(label.truncated)
+    }
+}

--- a/quickshell/tests/tst_portal_layout.qml
+++ b/quickshell/tests/tst_portal_layout.qml
@@ -65,7 +65,11 @@ TestCase {
         id: mockActivity
 
         property bool ambientMode: false
-        function noteUserActivity() {}
+        property int noteCount: 0
+        function noteUserActivity() {
+            noteCount += 1
+            ambientMode = false
+        }
     }
 
     QtObject {
@@ -73,7 +77,17 @@ TestCase {
 
         property bool reduceMotion: false
         property bool dimmed: false
-        function sync() {}
+        property string readyColorRole: "muted"
+        property string successColorRole: "green"
+        property string workingColorRole: "blue"
+        property string needsHelpColorRole: "yellow"
+        property string reviewReadyColorRole: "green"
+        property string errorColorRole: "red"
+        property string unknownColorRole: "magenta"
+        property string recordingColorRole: "green"
+        property string processingColorRole: "cyan"
+        property int syncCount: 0
+        function sync() { syncCount += 1 }
     }
 
     PortalView {
@@ -125,6 +139,19 @@ TestCase {
         mockBridge.orderRequests = 0
         mockBridge.lastOrder = ""
         portal.pendingAgentOrderRequest = ""
+        portal.paletteSettingsOpen = false
+        mockPreferences.readyColorRole = "muted"
+        mockPreferences.successColorRole = "green"
+        mockPreferences.workingColorRole = "blue"
+        mockPreferences.needsHelpColorRole = "yellow"
+        mockPreferences.reviewReadyColorRole = "green"
+        mockPreferences.errorColorRole = "red"
+        mockPreferences.unknownColorRole = "magenta"
+        mockPreferences.recordingColorRole = "green"
+        mockPreferences.processingColorRole = "cyan"
+        mockPreferences.syncCount = 0
+        mockActivity.ambientMode = false
+        mockActivity.noteCount = 0
         portal.currentPage = 0
         wait(0)
     }
@@ -132,6 +159,7 @@ TestCase {
     function cleanup() {
         mockStore.agents = []
         portal.currentPage = 0
+        portal.paletteSettingsOpen = false
         wait(0)
     }
 
@@ -244,5 +272,78 @@ TestCase {
         compare(label.text, "DEGRADED // " + reason.toUpperCase())
         compare(label.textFormat, Text.PlainText)
         verify(label.truncated)
+    }
+
+    function test_palettePaneMapsAllowlistedThemeRolesAndResets() {
+        var controls = findChild(portal, "globalDisplaySettings")
+        var toggle = findChild(controls, "paletteSettingButton")
+        var pane = findChild(portal, "paletteSettingsPane")
+        var scrim = findChild(portal, "paletteModalScrim")
+        var dimmer = findChild(portal, "displayDimmer")
+        verify(controls !== null)
+        verify(toggle !== null)
+        verify(pane !== null)
+        verify(scrim !== null)
+        verify(dimmer !== null)
+        compare(toggle.stateLabel, "THEME")
+        verify(toggle.activate())
+        compare(portal.paletteSettingsOpen, true)
+        compare(pane.open, true)
+        compare(toggle.stateLabel, "OPEN")
+        compare(mockActivity.noteCount, 1)
+        verify(pane.x >= 0)
+        verify(pane.y >= 0)
+        verify(pane.x + pane.width <= portal.width)
+        verify(pane.y + pane.height <= portal.height)
+        verify(scrim.z < pane.z)
+        verify(pane.z < dimmer.z)
+
+        var lastChoice = findChild(
+            pane, "paletteRole_processing_magenta"
+        )
+        verify(lastChoice !== null)
+        verify(lastChoice.x + lastChoice.width <= pane.width)
+        verify(lastChoice.y + lastChoice.height <= pane.height)
+
+        var redWorking = findChild(pane, "paletteRole_working_red")
+        verify(redWorking !== null)
+        verify(redWorking.activate())
+        compare(mockPreferences.workingColorRole, "red")
+        compare(mockPreferences.syncCount, 1)
+        compare(mockActivity.noteCount, 2)
+        compare(pane.customized, true)
+
+        var close = findChild(pane, "paletteCloseButton")
+        verify(close.activate())
+        compare(portal.paletteSettingsOpen, false)
+        compare(toggle.stateLabel, "CUSTOM")
+
+        portal.paletteSettingsOpen = true
+        var reset = findChild(pane, "paletteResetButton")
+        verify(reset.enabled)
+        verify(reset.activate())
+        compare(mockPreferences.workingColorRole, "blue")
+        compare(mockPreferences.syncCount, 2)
+        compare(pane.customized, false)
+        compare(pane.setMapping("working", "not-a-theme-role"), false)
+        compare(mockPreferences.workingColorRole, "blue")
+
+        mockPreferences.workingColorRole = "not-a-theme-role"
+        compare(pane.customized, true)
+        compare(pane.selectionFor("working", "blue"), "blue")
+        verify(reset.activate())
+        compare(mockPreferences.workingColorRole, "blue")
+    }
+
+    function test_palettePaneWakesAmbientAndClosesBeforeReentry() {
+        mockActivity.ambientMode = true
+        wait(0)
+        verify(portal.togglePaletteSettings())
+        compare(portal.paletteSettingsOpen, true)
+        compare(mockActivity.ambientMode, false)
+        compare(mockActivity.noteCount, 1)
+
+        mockActivity.ambientMode = true
+        tryCompare(portal, "paletteSettingsOpen", false)
     }
 }

--- a/quickshell/tests/tst_store.qml
+++ b/quickshell/tests/tst_store.qml
@@ -82,6 +82,7 @@ TestCase {
             "focused": false,
             "review_ready": false,
             "observed_for_seconds": 3,
+            "state_change_seq": 0,
             "source_order": sourceOrder,
             "terminal_text": "must be discarded",
             "prompt_text": "must be discarded",
@@ -132,6 +133,74 @@ TestCase {
         compare(store.health.status, "partial")
         compare(store.voice.state, "idle")
         compare(store.surfaceState(), "ready")
+    }
+
+    function test_incompatibleSessionSurfacesBoundedReason() {
+        var incompatible = snapshot(
+            11,
+            "epoch-incompatible",
+            [],
+            "reconnecting"
+        )
+        incompatible.sessions[0].state = "incompatible"
+        incompatible.sessions[0].protocol = 21
+        incompatible.sessions[0].message =
+            "Herdr protocol 21 is unsupported; expected 20"
+
+        verify(store.ingestEnvelope(incompatible))
+        compare(store.sessions[0].state, "incompatible")
+        compare(store.sessions[0].message,
+                "Herdr protocol 21 is unsupported; expected 20")
+        compare(store.connection.state, "reconnecting")
+        compare(store.connection.detail,
+                "Herdr protocol 21 is unsupported; expected 20")
+    }
+
+    function test_agentOrderSwitchesBetweenHerdrGroupedAndPriorityOrder() {
+        var grouped = snapshot(
+            1,
+            "epoch-order",
+            [
+                agent("workspace-first", 0, "idle"),
+                agent("attention-first", 1, "blocked")
+            ]
+        )
+        grouped.agent_order = {"available": true, "mode": "grouped"}
+        verify(store.ingestEnvelope(grouped))
+        compare(store.agentOrder.mode, "grouped")
+        compare(store.agents[0].id, "workspace-first")
+
+        var priority = snapshot(
+            2,
+            "epoch-order",
+            grouped.agents
+        )
+        priority.agent_order = {"available": true, "mode": "priority"}
+        verify(store.ingestEnvelope(priority))
+        compare(store.agentOrder.mode, "priority")
+        compare(store.agents[0].id, "attention-first")
+
+        var priorityTie = snapshot(
+            3,
+            "epoch-order",
+            [
+                Object.assign(agent("older-working", 0, "working"), {
+                    "state_change_seq": 3
+                }),
+                Object.assign(agent("newer-working", 1, "working"), {
+                    "state_change_seq": 9
+                })
+            ]
+        )
+        priorityTie.agent_order = {"available": true, "mode": "priority"}
+        verify(store.ingestEnvelope(priorityTie))
+        compare(store.agents[0].id, "newer-working")
+
+        var unavailable = snapshot(4, "epoch-order", grouped.agents)
+        unavailable.agent_order = {"available": false, "mode": "grouped"}
+        verify(store.ingestEnvelope(unavailable))
+        compare(store.agentOrder.available, false)
+        compare(store.agents[0].id, "attention-first")
     }
 
     function test_rejectsStaleSequenceButAcceptsNewEpoch() {

--- a/quickshell/tests/tst_theme.qml
+++ b/quickshell/tests/tst_theme.qml
@@ -21,7 +21,8 @@ TestCase {
         compare(parsed.foreground, "#abcdef")
         compare(parsed.muted, "#334455")
         compare(parsed.accent, "#102030")
-        verify(parsed.unknown === undefined)
+        compare(parsed.unknown, parsed.magenta)
+        verify(parsed.unknown !== "#ffffff")
     }
 
     function test_invalidOrPartialPaletteUsesSafeDefaults() {

--- a/quickshell/tests/tst_theme.qml
+++ b/quickshell/tests/tst_theme.qml
@@ -1,0 +1,257 @@
+import QtQuick
+import QtTest
+import "../state/ThemePalette.js" as ThemePalette
+
+TestCase {
+    name: "OmarchyThemePalette"
+
+    function test_parserAllowlistAndAliases() {
+        var parsed = ThemePalette.parse([
+            'mode = "light"',
+            'bg = "#123456"',
+            'fg = "#abcdef"',
+            'dark_fg = "#334455"',
+            'accent = "not-a-color"',
+            'blue = "#102030"',
+            'unknown = "#ffffff"'
+        ].join("\n"))
+
+        compare(parsed.mode, "light")
+        compare(parsed.background, "#123456")
+        compare(parsed.foreground, "#abcdef")
+        compare(parsed.muted, "#334455")
+        compare(parsed.accent, "#102030")
+        verify(parsed.unknown === undefined)
+    }
+
+    function test_invalidOrPartialPaletteUsesSafeDefaults() {
+        var parsed = ThemePalette.parse(
+            'accent = "broken"\nbackground = "#222222"\n'
+        )
+        compare(parsed.background, "#222222")
+        compare(parsed.accent, ThemePalette.fallback.accent)
+        compare(parsed.foreground, ThemePalette.fallback.foreground)
+        compare(parsed.mode, ThemePalette.fallback.mode)
+    }
+
+    function test_completePaletteMapsEveryChromeRole() {
+        var parsed = ThemePalette.parse([
+            'mode = "dark"',
+            'accent = "#445566"',
+            'background = "#101820"',
+            'foreground = "#f4ead5"',
+            'dark_bg = "#111111"',
+            'lighter_bg = "#333333"',
+            'muted = "#777777"',
+            'red = "#aa0000"',
+            'green = "#00aa00"',
+            'yellow = "#aaaa00"',
+            'blue = "#0000aa"',
+            'magenta = "#aa00aa"',
+            'cyan = "#00aaaa"',
+            'orange = "#aa5500"'
+        ].join("\n"))
+
+        compare(parsed.accent, "#445566")
+        compare(parsed.background, "#101820")
+        compare(parsed.foreground, "#f4ead5")
+        compare(parsed.darkBackground, "#111111")
+        compare(parsed.lighterBackground, "#333333")
+        compare(parsed.muted, "#777777")
+        compare(parsed.red, "#aa0000")
+        compare(parsed.green, "#00aa00")
+        compare(parsed.yellow, "#aaaa00")
+        compare(parsed.blue, "#0000aa")
+        compare(parsed.magenta, "#aa00aa")
+        compare(parsed.cyan, "#00aaaa")
+        compare(parsed.orange, "#aa5500")
+    }
+
+    function test_officialLightPaletteAliasesStayDarkAdaptiveAndReadable() {
+        var palettes = [
+            [
+                'mode = "light"',
+                'background = "#eff1f5"',
+                'dark_background = "#e3e4e8"',
+                'lighter_background = "#dce0e8"',
+                'foreground = "#4c4f69"',
+                'muted = "#acb0be"',
+                'accent = "#1e66f5"'
+            ],
+            [
+                'mode = "light"',
+                'background = "#fffcf0"',
+                'dark_background = "#f2efe4"',
+                'lighter_background = "#e6e4d9"',
+                'foreground = "#100f0f"',
+                'muted = "#b7b5ac"',
+                'accent = "#205ea6"'
+            ],
+            [
+                'mode = "light"',
+                'background = "#faf4ed"',
+                'dark_background = "#ede7e1"',
+                'lighter_background = "#f2e9e1"',
+                'foreground = "#575279"',
+                'muted = "#cecacd"',
+                'accent = "#56949f"'
+            ]
+        ]
+
+        for (var index = 0; index < palettes.length; index += 1) {
+            var parsed = ThemePalette.parse(palettes[index].join("\n"))
+            compare(parsed.mode, "light")
+            verify(parsed.canvas !== parsed.background)
+            verify(parsed.surface !== ThemePalette.fallback.surface)
+            verify(
+                ThemePalette.contrastRatio(
+                    parsed.textPrimary, parsed.surface
+                ) >= 7
+            )
+            verify(
+                ThemePalette.contrastRatio(
+                    parsed.textPrimary, parsed.surfaceRaised
+                ) >= 7
+            )
+            verify(
+                ThemePalette.contrastRatio(
+                    parsed.textSecondary, parsed.surface
+                ) >= 4.5
+            )
+            verify(
+                ThemePalette.contrastRatio(
+                    parsed.textMuted, parsed.surface
+                ) >= 4.5
+            )
+            verify(
+                ThemePalette.contrastRatio(
+                    parsed.textMuted, parsed.surfaceRaised
+                ) >= 4.5
+            )
+        }
+
+        var aliases = ThemePalette.parse(palettes[0].join("\n"))
+        compare(aliases.darkBackground, "#e3e4e8")
+        compare(aliases.lighterBackground, "#dce0e8")
+    }
+
+    function test_themeStatusHuesGetReadableTextVariantsOnDarkThemes() {
+        var palettes = [
+            [
+                'mode = "dark"',
+                'accent = "#81a1c1"',
+                'muted = "#4c566a"',
+                'background = "#2e3440"',
+                'dark_background = "#222730"',
+                'lighter_background = "#3b4252"',
+                'foreground = "#d8dee9"',
+                'red = "#bf616a"',
+                'green = "#a3be8c"',
+                'yellow = "#ebcb8b"',
+                'blue = "#81a1c1"'
+            ],
+            [
+                'mode = "dark"',
+                'accent = "#7fbbb3"',
+                'muted = "#475258"',
+                'background = "#2d353b"',
+                'dark_background = "#21272c"',
+                'lighter_background = "#343f44"',
+                'foreground = "#d3c6aa"',
+                'red = "#e67e80"',
+                'green = "#a7c080"',
+                'yellow = "#dbbc7f"',
+                'blue = "#7fbbb3"'
+            ]
+        ]
+        for (var paletteIndex = 0;
+                paletteIndex < palettes.length;
+                paletteIndex += 1) {
+            var parsed = ThemePalette.parse(
+                palettes[paletteIndex].join("\n")
+            )
+            var stateColors = [
+                parsed.blue,
+                parsed.yellow,
+                parsed.green,
+                parsed.red
+            ]
+            for (var colorIndex = 0;
+                    colorIndex < stateColors.length;
+                    colorIndex += 1) {
+                var stateColor = stateColors[colorIndex]
+                var surfaceText = ThemePalette.ensureContrast(
+                    stateColor, parsed.surface, 4.5
+                )
+                var raisedText = ThemePalette.ensureContrast(
+                    stateColor, parsed.surfaceRaised, 4.5
+                )
+                verify(
+                    ThemePalette.contrastRatio(
+                        surfaceText, parsed.surface
+                    ) >= 4.5
+                )
+                verify(
+                    ThemePalette.contrastRatio(
+                        raisedText, parsed.surfaceRaised
+                    ) >= 4.5
+                )
+                verify(
+                    ThemePalette.contrastRatio(
+                        ThemePalette.ensureContrast(
+                            stateColor, parsed.surfacePressed, 4.5
+                        ),
+                        parsed.surfacePressed
+                    ) >= 4.5
+                )
+                var pillBackground = ThemePalette.mixColors(
+                    parsed.surface, stateColor, 0.14
+                )
+                var pillText = ThemePalette.ensureContrast(
+                    stateColor, pillBackground, 4.5
+                )
+                verify(
+                    ThemePalette.contrastRatio(
+                        pillText, pillBackground
+                    ) >= 4.5
+                )
+            }
+
+            var voiceBackground = ThemePalette.mixColors(
+                parsed.surfaceRaised, parsed.green, 0.2
+            )
+            verify(
+                ThemePalette.contrastRatio(
+                    ThemePalette.ensureContrast(
+                        parsed.green, voiceBackground, 4.5
+                    ),
+                    voiceBackground
+                ) >= 4.5
+            )
+            verify(
+                ThemePalette.contrastRatio(
+                    ThemePalette.ensureContrast(
+                        parsed.textMuted, voiceBackground, 4.5
+                    ),
+                    voiceBackground
+                ) >= 4.5
+            )
+            verify(
+                ThemePalette.contrastRatio(
+                    ThemePalette.ensureContrast(
+                        parsed.textPrimary, parsed.surfacePressed, 7
+                    ),
+                    parsed.surfacePressed
+                ) >= 7
+            )
+            verify(
+                ThemePalette.contrastRatio(
+                    ThemePalette.ensureContrast(
+                        parsed.textMuted, parsed.surfacePressed, 4.5
+                    ),
+                    parsed.surfacePressed
+                ) >= 4.5
+            )
+        }
+    }
+}

--- a/quickshell/tests/tst_theme_mapping.qml
+++ b/quickshell/tests/tst_theme_mapping.qml
@@ -1,0 +1,93 @@
+import QtQuick
+import QtTest
+import "../state"
+import "../state/ThemePalette.js" as ThemePalette
+
+TestCase {
+    id: testCase
+
+    name: "ThemeMapping"
+    property var liveSource: ThemePalette.fallback
+
+    QtObject {
+        id: mockPreferences
+
+        property string readyColorRole: "muted"
+        property string successColorRole: "green"
+        property string workingColorRole: "blue"
+        property string needsHelpColorRole: "yellow"
+        property string reviewReadyColorRole: "green"
+        property string errorColorRole: "red"
+        property string unknownColorRole: "magenta"
+        property string recordingColorRole: "green"
+        property string processingColorRole: "cyan"
+    }
+
+    MappedTheme {
+        id: mapped
+        sourceTheme: testCase.liveSource
+        preferences: mockPreferences
+    }
+
+    function init() {
+        liveSource = ThemePalette.fallback
+        mockPreferences.readyColorRole = "muted"
+        mockPreferences.successColorRole = "green"
+        mockPreferences.workingColorRole = "blue"
+        mockPreferences.needsHelpColorRole = "yellow"
+        mockPreferences.reviewReadyColorRole = "green"
+        mockPreferences.errorColorRole = "red"
+        mockPreferences.unknownColorRole = "magenta"
+        mockPreferences.recordingColorRole = "green"
+        mockPreferences.processingColorRole = "cyan"
+    }
+
+    function test_defaultsPreserveReviewedSemanticMeanings() {
+        compare(String(mapped.ready), ThemePalette.fallback.muted)
+        compare(String(mapped.success), ThemePalette.fallback.green)
+        compare(String(mapped.working), ThemePalette.fallback.blue)
+        compare(String(mapped.needsHelp), ThemePalette.fallback.yellow)
+        compare(String(mapped.reviewReady), ThemePalette.fallback.green)
+        compare(String(mapped.error), ThemePalette.fallback.red)
+        compare(String(mapped.unknown), ThemePalette.fallback.magenta)
+        compare(String(mapped.recording), ThemePalette.fallback.green)
+        compare(String(mapped.processing), ThemePalette.fallback.cyan)
+    }
+
+    function test_eachMeaningCanSelectAThemePaletteRole() {
+        mockPreferences.readyColorRole = "cyan"
+        mockPreferences.successColorRole = "red"
+        mockPreferences.workingColorRole = "orange"
+        mockPreferences.needsHelpColorRole = "magenta"
+        mockPreferences.reviewReadyColorRole = "accent"
+        mockPreferences.errorColorRole = "yellow"
+        mockPreferences.unknownColorRole = "red"
+        mockPreferences.recordingColorRole = "blue"
+        mockPreferences.processingColorRole = "green"
+
+        compare(String(mapped.ready), ThemePalette.fallback.cyan)
+        compare(String(mapped.success), ThemePalette.fallback.red)
+        compare(String(mapped.working), ThemePalette.fallback.orange)
+        compare(String(mapped.needsHelp), ThemePalette.fallback.magenta)
+        compare(String(mapped.reviewReady), ThemePalette.fallback.accent)
+        compare(String(mapped.error), ThemePalette.fallback.yellow)
+        compare(String(mapped.unknown), ThemePalette.fallback.red)
+        compare(String(mapped.recording), ThemePalette.fallback.blue)
+        compare(String(mapped.processing), ThemePalette.fallback.green)
+    }
+
+    function test_invalidPersistedRolesFailClosedToDefaults() {
+        mockPreferences.workingColorRole = "#ffffff"
+        mockPreferences.errorColorRole = "background"
+        compare(String(mapped.working), ThemePalette.fallback.blue)
+        compare(String(mapped.error), ThemePalette.fallback.red)
+    }
+
+    function test_mappingFollowsAReplacedLiveThemePalette() {
+        mockPreferences.workingColorRole = "red"
+        liveSource = Object.assign({}, ThemePalette.fallback, {
+            "red": "#010203"
+        })
+        compare(String(mapped.working), "#010203")
+    }
+}


### PR DESCRIPTION
## What changed

- follow Omarchy's active runtime theme with validated palette parsing, safe fallbacks, and contrast-normalized semantic state colors
- add a top-right Palette pane that shows the current Omarchy swatches and persistently maps allowlisted theme roles onto Ready, Success, Working, Needs Help, Review Ready, Error, Unknown, Recording, and Processing
- expand the fixed 2560x720 command center to 14 agents per page, add Herdr Space labels, and render up to 14 agents in Ambient view
- preserve the original independent ambient motion through six agents and extend its advancing, crossing lane character for denser populations
- synchronize grouped/priority ordering with Herdr's authoritative public API
- update the adapter for the custom protocol-20 Herdr fork and preserve Herdr's priority tie ordering
- restore bounded Claude, Codex, and OpenCode usage collection after Omarchy's usage-record migration
- make quota-window labels font-metric aware so Claude/Codex labels do not truncate on hosted Arch runners
- add QML, Rust, protocol, layout, animation, accessibility, persistence-boundary, and bounded-data regressions

## Why

The installed portal had outgrown its original six-agent/static-palette assumptions. Dense Herdr sessions needed pagination and grouping context, the Ambient view needed the same population ceiling without becoming a rigid formation, and ordering needed to remain consistent with Herdr rather than introducing a portal-only preference. Omarchy themes also vary enough that fixed semantic-role choices do not always read well, so the portal now keeps theme ownership while allowing each XENEON meaning to select an allowlisted live swatch. Omarchy's usage migration also made the prior capacity inputs unavailable, so the daemon now consumes the current trusted records and a bounded read-only OpenCode aggregate.

## Validation

- `mise exec -- just check`
- 78 Rust core tests and 1 CLI test
- strict rustfmt and Clippy with warnings denied
- ShellCheck
- 27 Python QML contract tests
- 112 Qt/QML tests
- 31 installer/integration scenarios
- `git diff --check`
- independent Claude review/fix/re-review found no remaining P0-P2 issues
- reviewed source installed after exact output/touch preflight; both user services active with zero restarts, deployed Quickshell tree matches source, and Hyprland config errors are empty
- compositor-native 2560x720 Tokyo Night capture confirms the Palette control and 14-card command-center layout

## Remaining live gates

- physically open and exercise the Palette pane on the EDGE across a second Omarchy theme; the installed cua-driver 0.7.1 cannot capture this multi-monitor Wayland layer surface
- capture the second 20-agent command-center page on the physical EDGE
- complete the controlled cold handoff to the reviewed custom Herdr package; ordering remains unavailable while the stock 64-descriptor server is active
- broader hardware checks for DPMS, suspend/resume, privacy, guarded holds, and DDC restore remain tracked separately
