### PR TITLE
Fix header actions and terminal-hosted Herdr focus

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,7 +106,8 @@ state; the daemon and portal run only while that exact hardware is present.
 | --- | --- | --- | --- |
 | Foundation and Rust adapter | `main` | Rust workspace, schemas, fixtures | Complete through `c32b5cd` |
 | Herdr safe actions | `agent/xeneon-safe-actions` in the Herdr repository | Public Herdr API, PTY guard, tests, next docs | Installed from reviewed v0.8.0 head `fd53378d`; not pushed |
-| Shared agent ordering | `xeneon-order-mode-sync` in `herdr-worktrees/xeneon-order-mode-sync` plus `omarchy-theme-sync` here | Herdr `agent.order.get/set`, adapter snapshot/action, QML toggle, ordering and motion tests | XENEON follow-up installed and independently reviewed; Herdr live handoff is blocked by the running server's 64-pane limit (67 panes present), so ordering remains unavailable |
+| Shared agent ordering | `xeneon-order-mode-sync` in `herdr-worktrees/xeneon-order-mode-sync` plus `header-launch-order-fix` here | Herdr `agent.order.get/set`, adapter snapshot/action, QML toggle, ordering and motion tests | Reviewed fork `51af53be` installed to `~/.local/bin/herdr` and activated through a 52-pane live handoff; portal ordering is available and grouped/priority round trips synchronize through Herdr's public API |
+| Header launcher repair | `header-launch-order-fix` | move the fixed ChatGPT/Claude actions beside ordering, update the allowlisted ChatGPT desktop ID, verify both launch/focus paths, and reactivate authoritative ordering | Source-reviewed, installed, and live-verified: fixed ChatGPT/Claude actions sit after Order, direct sandbox-safe `uwsm app` launches both exact desktop classes, and existing windows focus without arbitrary input |
 | Quickshell portal | `main` | `quickshell/`, QML tests | Complete through `34e6037` |
 | Live naming, voice, and ambient ring UX | `agent/portal-voice-ring` in `portal-voice-ring` worktree | normalized public protocol fields, `quickshell/`, fixtures, UX docs/tests | Live on the physical EDGE; remaining power/privacy checks are open |
 | Concept motion parity | `agent/portal-voice-ring` in `portal-voice-ring` worktree | ambient presentation, preview timing, visual QA | Live on the physical EDGE; remaining power/privacy checks are open |
@@ -119,6 +120,12 @@ state; the daemon and portal run only while that exact hardware is present.
 | Hotplug lifecycle | `hotplug-lifecycle` in `hotplug-lifecycle` worktree | lifecycle reconciler, user units, Hyprland event hook, runtime connector override, installer/tests | Installed and independently reviewed; exact `DP-2` unplug stopped both services and replug restored the stack and touch mapping; burst and mid-settle races are covered by regression tests |
 | Global display controls | `agent/portal-voice-ring` in `portal-voice-ring` worktree | persistent presentation settings, reduced-motion composition, dim veil | Live on the physical EDGE; default full-motion/normal-screen state restored |
 | Omarchy integration | `agent/portal-voice-ring` in `portal-voice-ring` worktree | `config/`, `scripts/`, services, install tests | Production user integration installed and active on the physical EDGE |
+
+Header/order review workers `header_order_review` (Claude, pane `wW:pP`) and
+`header_launch_service_review` (Claude, pane `wW:pQ`, tab `wW:tG`) completed
+read-only review/fix/re-review loops with no remaining P0-P2 findings. Both
+loop-created resources were closed; the orchestrator owned all fixes,
+verification, installation, and the live handoff.
 
 ## Allowed actions
 
@@ -300,62 +307,43 @@ state; the daemon and portal run only while that exact hardware is present.
       tests, independent reviews, a
       reviewed Herdr live handoff, physical toggle verification from both UIs,
       and physical ambient visual QA.
+- [x] Header/order software and live API gate: the reviewed Herdr `51af53be`
+      package replaced the stock server through a state-preserving 52-pane
+      handoff; ordering round-tripped priority to grouped and back through the
+      XENEON typed action plus Herdr public socket. The reviewed XENEON build
+      was installed, and no-window launch plus existing-window focus passed for
+      the exact ChatGPT and Claude desktop identities.
 
 ## Current local state
 
-- Active goal (2026-08-13): replace the stock Omarchy Herdr protocol-20
-  installation with the reviewed custom fork rebased onto exact packaged commit
-  `0766aa57ee0ceb4410ae064e94c0f0557853eee7`, update XENEON for protocol 20,
-  and restore guarded actions plus grouped/priority synchronization. Done
-  requires focused and broad gates in both repositories, independent review,
-  a state-preserving Herdr live handoff, reviewed XENEON reinstall, live API
-  and physical EDGE verification, and cleanup of only loop-created resources.
-  Visible implementation worker `herdr_p20_impl` (Codex) runs in Herdr pane
-  `wW:pF`, tab `wW:t1`, workspace `wW`, cwd/worktree
-  `/home/sbull/src/github.com/spencerbull/herdr-worktrees/xeneon-order-mode-sync`,
-  branch `xeneon-order-mode-sync`; the orchestrator owns verification and pane
-  cleanup. A second visible Codex worker, `herdr_handoff_cap`, owns only the
-  bounded 79-pane live-handoff prerequisite in pane `wW:pG`, tab `wW:t1`,
-  workspace `wW`, cwd/worktree
-  `/home/sbull/src/github.com/spencerbull/herdr-worktrees/xeneon-handoff-capacity`,
-  branch `xeneon-handoff-capacity`; the orchestrator owns integration, review,
-  and cleanup. The XENEON independent pre-install review found three P2
-  acceptance/handoff gaps (explicit protocol-19 rejection, rendered degraded
-  reason coverage, and stale ledger evidence); all were remediated and the
-  final re-review is GO with no P0-P2 findings. XENEON is installed and live;
-  the Herdr branch is pushed and its reviewed package is built, but privileged
-  package installation remains at the visible sudo prompt. No PR is planned
-  against upstream under its external-contributor policy.
+- Active goal (2026-08-13): the software and live-API portion of replacing the
+  stock Omarchy Herdr protocol-20 server is complete. The reviewed fork is
+  user-installed from package commit `51af53be`, the state-preserving handoff
+  succeeded, guarded actions remain available, and grouped/priority ordering
+  synchronizes through Herdr and XENEON. The reviewed XENEON release is also
+  installed. Remaining goal gates are the physical EDGE touchscreen toggle,
+  a matching Herdr-UI toggle, and final ambient visual QA. No PR is planned
+  against Herdr upstream under its external-contributor policy.
 
 - The 14-agent layout source and cleanup gates are complete: QML tests prove
   14+6 pagination, a temporary 20-agent Herdr population physically verified
   the first 14-card page plus the fourteen-node ambient view, and all 11
   disposable tabs were closed. A physical second-page screenshot remains open.
-- The grouped/priority follow-up is source-complete in isolated Herdr branch
-  `xeneon-order-mode-sync`, now rebased onto exact Omarchy protocol-20 commit
-  `0766aa57` with a reviewed 128-descriptor handoff prerequisite for the current
-  79-pane session, plus the current XENEON branch. The integrated Herdr gate
-  passes 3,465 Rust tests, strict Clippy including Windows, UI/integration/
-  marketplace suites, and 98 maintenance/schema/docs/vendor tests. The current
-  XENEON gate passes 78 Rust core tests, 104 Qt tests, 27 Python contracts, and
-  all 31 installer scenarios. The final XENEON re-review is GO; the reviewed
-  release binaries and full Quickshell tree are installed. Live validation
-  reports one connected protocol-20 session with 18 agents, zero service
-  restarts, 0-1% sampled daemon CPU after replacing the stale release artifact,
-  clean `scripts/check.sh`/`hyprctl configerrors`, and a visually inspected
-  2560x720 EDGE frame with 14 cards on page one. The prior reviewed Herdr
-  handoff made no state change because the
-  then-running server had 67 panes and v0.8.0 refused more than 64. The retained
-  backup remains available. The custom Herdr branch is pushed to the fork at
-  `51af53be`; its epoch-1 Arch package is built and reviewed, but awaits the
-  user's sudo password. The running stock server remains intentionally intact,
-  so ordering is unavailable in the portal until a future controlled cold
-  restart activates the installed fork; the stock 64-descriptor exporter cannot
-  preserve the current 79-plus-pane session through a live handoff.
-  The previously reviewed XENEON side is installed: physical EDGE frames
-  with 14 agents confirm the bounded independent lanes change relative order,
-  cross, and overlap instead of moving as a rigid revolving formation. Both
-  application services remained active with zero restarts during that check.
+- The grouped/priority follow-up is live on the isolated Herdr branch
+  `xeneon-order-mode-sync` at `51af53be` and current XENEON branch
+  `header-launch-order-fix`. After the pane population fell to 52, the reviewed
+  epoch-1 Herdr package was installed user-locally and a state-preserving live
+  handoff replaced `/usr/bin/herdr` with `~/.local/bin/herdr` without closing
+  this session. XENEON reports one connected protocol-20 session, 18 agents,
+  and authoritative priority ordering; a typed priority-to-grouped-to-priority
+  round trip matched `agent.order.get` after every step. The current XENEON
+  gate passes 81 Rust core tests plus the CLI test, strict Clippy/rustfmt, 27
+  Python and 113 Qt QML tests, all 31 installer scenarios, `qmllint`, and
+  `git diff --check`. Independent Claude reviews are GO. The release daemon and
+  Quickshell tree are installed; both services are active. Live typed actions
+  launched exact ChatGPT and Claude desktop classes from no-window state and
+  focused an existing Claude window. Physical touchscreen presses and a Herdr
+  UI-side toggle remain human gates.
 
 - `omarchy-theme-sync` is based on current `origin/main` and contains the
   pushed theme integration, semantic state-role follow-up, dense layout,

--- a/TODO.md
+++ b/TODO.md
@@ -433,6 +433,21 @@ verification, installation, and the live handoff.
 
 ## Open checkpoints
 
+- Repair the installed Herdr focus handoff on branch
+  `header-launch-order-fix`. Done requires an exact process/session-owned
+  compositor selection regression, focused and broad Rust gates, independent
+  review, a pushed PR, an exact reviewed local install, and a live typed open
+  action that both focuses the Herdr agent and activates its hosting window.
+  Do not weaken selection to a generic terminal class/title or focus an
+  unrelated terminal when the session identity is absent or ambiguous.
+  Independent Claude reviewer `xeneon_focus_review` ran in Herdr pane `wW:pR`,
+  found and re-reviewed the CLI/session/environment/focus-history boundaries,
+  and returned GO with no P0-P2 after 15 focused desktop tests and strict
+  Clippy. The reviewer pane was then closed by this loop. Final source gates
+  pass 87 Rust core tests plus the CLI test, strict workspace Clippy/rustfmt,
+  27 Python and 113 Qt QML tests, all 31 installer scenarios, ShellCheck,
+  `luac -p`, and `git diff --check`; publication, installation, and live
+  typed-open verification remain.
 - Complete the Claude Fable 5 ACP review/fix/re-review loop on
   `claude-fable-review`; do not include or modify the pre-existing untracked
   `packaging/` artifacts.

--- a/crates/xeneon-agent-core/src/desktop.rs
+++ b/crates/xeneon-agent-core/src/desktop.rs
@@ -33,6 +33,7 @@ pub enum DesktopAppOutcome {
 struct DesktopAppSpec {
     desktop_id: &'static str,
     class: &'static str,
+    main_title: &'static str,
 }
 
 #[derive(Debug, Clone)]
@@ -41,7 +42,7 @@ pub struct DesktopController {
     remembered_window: Arc<Mutex<Option<String>>>,
     launching_since: Arc<Mutex<HashMap<DesktopApp, Instant>>>,
     hyprctl_bin: PathBuf,
-    uwsm_app_bin: PathBuf,
+    uwsm_bin: PathBuf,
     launch_poll_interval: Duration,
     launch_observation_timeout: Duration,
     launch_coalesce_for: Duration,
@@ -56,8 +57,14 @@ struct HyprClient {
     initial_class: String,
     #[serde(default)]
     title: String,
+    #[serde(default, rename = "initialTitle")]
+    initial_title: String,
     pid: i32,
     monitor: i64,
+    #[serde(default)]
+    floating: bool,
+    #[serde(default, rename = "focusHistoryID")]
+    focus_history_id: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -75,7 +82,7 @@ impl DesktopController {
             remembered_window: Arc::new(Mutex::new(None)),
             launching_since: Arc::new(Mutex::new(HashMap::new())),
             hyprctl_bin: PathBuf::from("hyprctl"),
-            uwsm_app_bin: PathBuf::from("uwsm-app"),
+            uwsm_bin: PathBuf::from("uwsm"),
             launch_poll_interval: Duration::from_millis(100),
             launch_observation_timeout: Duration::from_secs(12),
             launch_coalesce_for: Duration::from_secs(20),
@@ -133,14 +140,13 @@ impl DesktopController {
     pub async fn focus_or_launch(&self, app: DesktopApp) -> Result<DesktopAppOutcome> {
         let spec = desktop_app_spec(app);
         let clients = hypr_json::<Vec<HyprClient>>(&self.hyprctl_bin, &["clients", "-j"]).await?;
-        let candidates = desktop_candidates(&clients, spec);
-        match candidates.as_slice() {
-            [client] => {
+        match select_desktop_candidate(&clients, spec)? {
+            Some(client) => {
                 self.launching_since.lock().await.remove(&app);
                 dispatch_focus(&self.hyprctl_bin, &client.address).await?;
                 Ok(DesktopAppOutcome::Focused)
             }
-            [] => {
+            None => {
                 let now = Instant::now();
                 let mut launches = self.launching_since.lock().await;
                 let launch_in_flight = launches
@@ -150,19 +156,13 @@ impl DesktopController {
                     launches.insert(app, now);
                 }
                 drop(launches);
-                if !launch_in_flight
-                    && let Err(error) = launch_desktop(&self.uwsm_app_bin, spec).await
+                if !launch_in_flight && let Err(error) = launch_desktop(&self.uwsm_bin, spec).await
                 {
                     self.launching_since.lock().await.remove(&app);
                     return Err(error);
                 }
                 self.wait_for_launched_client(app, spec).await
             }
-            _ => bail!(
-                "expected at most one {} window, found {}",
-                spec.class,
-                candidates.len()
-            ),
         }
     }
 
@@ -174,23 +174,30 @@ impl DesktopController {
         let deadline = Instant::now() + self.launch_observation_timeout;
         loop {
             let clients =
-                hypr_json::<Vec<HyprClient>>(&self.hyprctl_bin, &["clients", "-j"]).await?;
-            let candidates = desktop_candidates(&clients, spec);
-            match candidates.as_slice() {
-                [client] => {
+                match hypr_json::<Vec<HyprClient>>(&self.hyprctl_bin, &["clients", "-j"]).await {
+                    Ok(clients) => clients,
+                    Err(error) => {
+                        self.launching_since.lock().await.remove(&app);
+                        return Err(error);
+                    }
+                };
+            let candidate = match select_desktop_candidate(&clients, spec) {
+                Ok(candidate) => candidate,
+                Err(error) => {
+                    self.launching_since.lock().await.remove(&app);
+                    return Err(error);
+                }
+            };
+            match candidate {
+                Some(client) => {
                     self.launching_since.lock().await.remove(&app);
                     dispatch_focus(&self.hyprctl_bin, &client.address).await?;
                     return Ok(DesktopAppOutcome::LaunchedAndFocused);
                 }
-                [] if Instant::now() < deadline => sleep(self.launch_poll_interval).await,
-                [] => bail!("desktop client did not map before the launch deadline"),
-                _ => {
+                None if Instant::now() < deadline => sleep(self.launch_poll_interval).await,
+                None => {
                     self.launching_since.lock().await.remove(&app);
-                    bail!(
-                        "expected one {} window after launch, found {}",
-                        spec.class,
-                        candidates.len()
-                    );
+                    bail!("desktop client did not map before the launch deadline");
                 }
             }
         }
@@ -227,22 +234,82 @@ fn desktop_candidates(clients: &[HyprClient], spec: DesktopAppSpec) -> Vec<&Hypr
         .collect()
 }
 
+fn select_desktop_candidate(
+    clients: &[HyprClient],
+    spec: DesktopAppSpec,
+) -> Result<Option<&HyprClient>> {
+    let candidates = desktop_candidates(clients, spec);
+    if candidates.len() <= 1 {
+        return Ok(candidates.into_iter().next());
+    }
+
+    let titled: Vec<_> = candidates
+        .iter()
+        .copied()
+        .filter(|client| client.initial_title.eq_ignore_ascii_case(spec.main_title))
+        .collect();
+    let candidates = if titled.is_empty() {
+        candidates
+    } else {
+        titled
+    };
+    if candidates.len() == 1 {
+        return Ok(candidates.into_iter().next());
+    }
+
+    let tiled: Vec<_> = candidates
+        .iter()
+        .copied()
+        .filter(|client| !client.floating)
+        .collect();
+    let candidates = if tiled.is_empty() { candidates } else { tiled };
+    if candidates.len() == 1 {
+        return Ok(candidates.into_iter().next());
+    }
+
+    let best_history = candidates
+        .iter()
+        .filter_map(|client| client.focus_history_id)
+        .min();
+    if let Some(best_history) = best_history {
+        let recent: Vec<_> = candidates
+            .iter()
+            .copied()
+            .filter(|client| client.focus_history_id == Some(best_history))
+            .collect();
+        if recent.len() == 1 {
+            return Ok(recent.into_iter().next());
+        }
+    }
+
+    bail!(
+        "ambiguous {} desktop clients after title, tiling, and focus-history checks",
+        spec.class
+    )
+}
+
 fn desktop_app_spec(app: DesktopApp) -> DesktopAppSpec {
     match app {
         DesktopApp::ChatGpt => DesktopAppSpec {
-            desktop_id: "chatgpt-linux-poc.desktop",
-            class: "chatgpt-linux-poc",
+            desktop_id: "chatgpt.desktop",
+            class: "chatgpt",
+            main_title: "ChatGPT",
         },
         DesktopApp::Claude => DesktopAppSpec {
             desktop_id: "com.anthropic.Claude.desktop",
             class: "com.anthropic.Claude",
+            main_title: "Claude",
         },
     }
 }
 
-async fn launch_desktop(uwsm_app_bin: &Path, spec: DesktopAppSpec) -> Result<()> {
-    let mut child = Command::new(uwsm_app_bin)
-        .args(["--", "gtk-launch", spec.desktop_id])
+async fn launch_desktop(uwsm_bin: &Path, spec: DesktopAppSpec) -> Result<()> {
+    let mut child = Command::new(uwsm_bin)
+        // Bypass uwsm-app's runtime-directory lock/FIFO wrapper: the daemon's
+        // sandbox can read the UWSM pipes but may only write its owned runtime
+        // directory. A graphical service also avoids moving this already
+        // service-owned caller into a scope.
+        .args(["app", "-t", "service", "--", spec.desktop_id])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -491,8 +558,9 @@ mod tests {
         assert_eq!(
             desktop_app_spec(DesktopApp::ChatGpt),
             DesktopAppSpec {
-                desktop_id: "chatgpt-linux-poc.desktop",
-                class: "chatgpt-linux-poc",
+                desktop_id: "chatgpt.desktop",
+                class: "chatgpt",
+                main_title: "ChatGPT",
             }
         );
         assert_eq!(
@@ -500,8 +568,39 @@ mod tests {
             DesktopAppSpec {
                 desktop_id: "com.anthropic.Claude.desktop",
                 class: "com.anthropic.Claude",
+                main_title: "Claude",
             }
         );
+    }
+
+    #[test]
+    fn desktop_candidate_prefers_main_window_then_recent_focus() {
+        let clients: Vec<HyprClient> = serde_json::from_str(
+            r#"[
+                {"address":"0x1","class":"chatgpt","initialClass":"chatgpt","title":"Quick Chat","initialTitle":"Quick Chat","pid":1,"monitor":0,"floating":true,"focusHistoryID":0},
+                {"address":"0x2","class":"chatgpt","initialClass":"chatgpt","title":"Thread A","initialTitle":"ChatGPT","pid":2,"monitor":0,"floating":false,"focusHistoryID":4},
+                {"address":"0x3","class":"chatgpt","initialClass":"chatgpt","title":"Thread B","initialTitle":"ChatGPT","pid":3,"monitor":0,"floating":false,"focusHistoryID":1}
+            ]"#,
+        )
+        .unwrap();
+
+        let selected = select_desktop_candidate(&clients, desktop_app_spec(DesktopApp::ChatGpt))
+            .unwrap()
+            .unwrap();
+        assert_eq!(selected.address, "0x3");
+    }
+
+    #[test]
+    fn desktop_candidate_fails_closed_when_narrowing_is_still_ambiguous() {
+        let clients: Vec<HyprClient> = serde_json::from_str(
+            r#"[
+                {"address":"0x1","class":"chatgpt","initialClass":"chatgpt","title":"Thread A","initialTitle":"ChatGPT","pid":1,"monitor":0,"floating":false},
+                {"address":"0x2","class":"chatgpt","initialClass":"chatgpt","title":"Thread B","initialTitle":"ChatGPT","pid":2,"monitor":0,"floating":false}
+            ]"#,
+        )
+        .unwrap();
+
+        assert!(select_desktop_candidate(&clients, desktop_app_spec(DesktopApp::ChatGpt)).is_err());
     }
 
     #[test]
@@ -519,7 +618,7 @@ mod tests {
         assert!(is_portal_preview_class(
             "org.xeneon-edge.agent-portal-preview.123"
         ));
-        assert!(!is_portal_preview_class("chatgpt-linux-poc"));
+        assert!(!is_portal_preview_class("chatgpt"));
     }
 
     #[tokio::test]
@@ -529,14 +628,14 @@ mod tests {
         let launch_log = temp.path().join("launch.log");
         let focus_log = temp.path().join("focus.log");
         let hyprctl = temp.path().join("hyprctl");
-        let uwsm_app = temp.path().join("uwsm-app");
+        let uwsm = temp.path().join("uwsm");
         write_executable(
             &hyprctl,
             &format!(
                 r#"#!/bin/sh
 if [ "$1" = "clients" ]; then
   if [ -e "{marker}" ]; then
-    printf '%s\n' '[{{"address":"0xdef","class":"com.anthropic.Claude","initialClass":"com.anthropic.Claude","title":"Claude","pid":43,"monitor":0}},{{"address":"0xabc","class":"chatgpt-linux-poc","initialClass":"chatgpt-linux-poc","title":"ChatGPT","pid":42,"monitor":0}}]'
+    printf '%s\n' '[{{"address":"0xdef","class":"com.anthropic.Claude","initialClass":"com.anthropic.Claude","title":"Claude","pid":43,"monitor":0}},{{"address":"0xabc","class":"chatgpt","initialClass":"chatgpt","title":"ChatGPT","pid":42,"monitor":0}}]'
   else
     printf '%s\n' '[{{"address":"0xdef","class":"com.anthropic.Claude","initialClass":"com.anthropic.Claude","title":"Claude","pid":43,"monitor":0}}]'
   fi
@@ -552,7 +651,7 @@ fi
             ),
         );
         write_executable(
-            &uwsm_app,
+            &uwsm,
             &format!(
                 r#"#!/bin/sh
 printf '%s\n' "$*" >> "{launch_log}"
@@ -566,7 +665,7 @@ sleep 1
 
         let mut controller = DesktopController::new(DesktopConfig::default());
         controller.hyprctl_bin = hyprctl;
-        controller.uwsm_app_bin = uwsm_app;
+        controller.uwsm_bin = uwsm;
         controller.launch_poll_interval = Duration::from_millis(10);
         controller.launch_observation_timeout = Duration::from_secs(2);
         controller.launch_coalesce_for = Duration::from_secs(3);
@@ -607,8 +706,60 @@ sleep 1
             second.await.unwrap().unwrap(),
             DesktopAppOutcome::LaunchedAndFocused
         );
-        assert_eq!(fs::read_to_string(launch_log).unwrap().lines().count(), 1);
+        assert_eq!(fs::read_to_string(&launch_log).unwrap().lines().count(), 1);
+        assert_eq!(
+            fs::read_to_string(launch_log).unwrap().trim(),
+            "app -t service -- chatgpt.desktop"
+        );
         assert_eq!(fs::read_to_string(focus_log).unwrap().lines().count(), 3);
+    }
+
+    #[tokio::test]
+    async fn failed_mapping_clears_launch_coalescing_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let launch_log = temp.path().join("launch.log");
+        let hyprctl = temp.path().join("hyprctl");
+        let uwsm = temp.path().join("uwsm");
+        write_executable(
+            &hyprctl,
+            r#"#!/bin/sh
+if [ "$1" = "clients" ]; then
+  printf '%s\n' '[]'
+else
+  printf '%s\n' '{}'
+fi
+"#,
+        );
+        write_executable(
+            &uwsm,
+            &format!(
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> "{launch_log}"
+"#,
+                launch_log = launch_log.display()
+            ),
+        );
+
+        let mut controller = DesktopController::new(DesktopConfig::default());
+        controller.hyprctl_bin = hyprctl;
+        controller.uwsm_bin = uwsm;
+        controller.launch_poll_interval = Duration::from_millis(2);
+        controller.launch_observation_timeout = Duration::from_millis(15);
+        controller.launch_coalesce_for = Duration::from_secs(10);
+
+        assert!(
+            controller
+                .focus_or_launch(DesktopApp::ChatGpt)
+                .await
+                .is_err()
+        );
+        assert!(
+            controller
+                .focus_or_launch(DesktopApp::ChatGpt)
+                .await
+                .is_err()
+        );
+        assert_eq!(fs::read_to_string(launch_log).unwrap().lines().count(), 2);
     }
 
     fn write_executable(path: &Path, contents: &str) {

--- a/crates/xeneon-agent-core/src/desktop.rs
+++ b/crates/xeneon-agent-core/src/desktop.rs
@@ -205,23 +205,84 @@ impl DesktopController {
 
     pub async fn activate_herdr(&self, session: &str, socket_path: &Path) -> Result<()> {
         let (clients, _) = hypr_state(&self.hyprctl_bin).await?;
-        let class = self.config.herdr_class.to_ascii_lowercase();
-        let candidates: Vec<_> = clients
-            .iter()
-            .filter(|client| {
-                client.class.to_ascii_lowercase().contains(&class)
-                    || client.title.to_ascii_lowercase().contains(&class)
-            })
-            .filter(|client| client_hosts_session(client.pid, session, socket_path))
-            .collect();
-        if candidates.len() != 1 {
-            bail!(
-                "expected one Herdr window for session {session}, found {}",
-                candidates.len()
-            );
-        }
-        dispatch_focus(&self.hyprctl_bin, &candidates[0].address).await
+        let processes = tokio::task::spawn_blocking(process_table)
+            .await
+            .context("inventorying Herdr client processes")?;
+        let candidate = select_herdr_candidate(
+            &clients,
+            &processes,
+            session,
+            socket_path,
+            &self.config.herdr_class,
+        )?;
+        dispatch_focus(&self.hyprctl_bin, &candidate.address).await
     }
+}
+
+fn select_herdr_candidate<'a>(
+    clients: &'a [HyprClient],
+    processes: &HashMap<i32, ProcessInfo>,
+    session: &str,
+    socket_path: &Path,
+    identity_hint: &str,
+) -> Result<&'a HyprClient> {
+    let session_clients: Vec<_> = clients
+        .iter()
+        .filter(|client| client_hosts_session_in(client.pid, session, socket_path, processes))
+        .collect();
+    if session_clients.is_empty() {
+        bail!("no compositor window hosts Herdr session {session}");
+    }
+
+    // Native Herdr windows can use the configured class/title. Terminal-hosted
+    // Herdr views inherit the terminal class, so the hint may legitimately
+    // match none; exact process/session ownership remains the authority.
+    let hint = identity_hint.to_ascii_lowercase();
+    let hinted: Vec<_> = session_clients
+        .iter()
+        .copied()
+        .filter(|client| {
+            client.class.to_ascii_lowercase().contains(&hint)
+                || client.initial_class.to_ascii_lowercase().contains(&hint)
+                || client.title.to_ascii_lowercase().contains(&hint)
+                || client.initial_title.to_ascii_lowercase().contains(&hint)
+        })
+        .collect();
+    let candidates = if hinted.is_empty() {
+        session_clients
+    } else {
+        hinted
+    };
+    if candidates.len() == 1 {
+        return Ok(candidates[0]);
+    }
+
+    if candidates
+        .iter()
+        .any(|client| client.focus_history_id.is_none())
+    {
+        bail!("Herdr session {session} has compositor windows without focus history");
+    }
+
+    let Some(most_recent) = candidates
+        .iter()
+        .filter_map(|client| client.focus_history_id)
+        .min()
+    else {
+        bail!("Herdr session {session} has no usable focus history");
+    };
+    let recent: Vec<_> = candidates
+        .iter()
+        .copied()
+        .filter(|client| client.focus_history_id == Some(most_recent))
+        .collect();
+    if recent.len() != 1 {
+        bail!(
+            "Herdr session {session} has {} equally recent compositor windows",
+            recent.len()
+        );
+    }
+    Ok(recent[0])
 }
 
 fn desktop_candidates(clients: &[HyprClient], spec: DesktopAppSpec) -> Vec<&HyprClient> {
@@ -265,6 +326,13 @@ fn select_desktop_candidate(
     let candidates = if tiled.is_empty() { candidates } else { tiled };
     if candidates.len() == 1 {
         return Ok(candidates.into_iter().next());
+    }
+
+    if candidates
+        .iter()
+        .any(|client| client.focus_history_id.is_none())
+    {
+        bail!("desktop candidates lack complete focus history");
     }
 
     let best_history = candidates
@@ -396,10 +464,14 @@ fn focus_expression(address: &str) -> Result<String> {
     ))
 }
 
-fn client_hosts_session(client_pid: i32, session: &str, socket_path: &Path) -> bool {
-    let processes = process_table();
+fn client_hosts_session_in(
+    client_pid: i32,
+    session: &str,
+    socket_path: &Path,
+    processes: &HashMap<i32, ProcessInfo>,
+) -> bool {
     processes.iter().any(|(pid, process)| {
-        is_descendant(*pid, client_pid, &processes)
+        is_descendant(*pid, client_pid, processes)
             && command_matches_session(&process.command, &process.environment, session, socket_path)
     })
 }
@@ -424,12 +496,18 @@ fn process_table() -> HashMap<i32, ProcessInfo> {
         let Some(parent) = process_parent(&path.join("stat")) else {
             continue;
         };
+        let command = nul_fields(&path.join("cmdline"));
+        let environment = if interactive_herdr_session(&command).is_some() {
+            nul_fields(&path.join("environ"))
+        } else {
+            Vec::new()
+        };
         table.insert(
             pid,
             ProcessInfo {
                 parent,
-                command: nul_fields(&path.join("cmdline")),
-                environment: nul_fields(&path.join("environ")),
+                command,
+                environment,
             },
         );
     }
@@ -478,35 +556,84 @@ fn command_matches_session(
     session: &str,
     socket_path: &Path,
 ) -> bool {
+    let Some(command_session) = interactive_herdr_session(command) else {
+        return false;
+    };
+    let expected_socket = socket_path.to_string_lossy();
+    let environment_session = environment
+        .iter()
+        .find_map(|value| value.strip_prefix("HERDR_SESSION="));
+    let environment_socket = environment
+        .iter()
+        .find_map(|value| value.strip_prefix("HERDR_SOCKET_PATH="));
+    match command_session {
+        HerdrClientSession::Named(value) => {
+            !environment_session.is_some_and(|environment| environment != value) && value == session
+        }
+        HerdrClientSession::Default => {
+            if environment_session.is_some_and(|value| value != session)
+                || environment_socket.is_some_and(|value| value != expected_socket)
+            {
+                return false;
+            }
+            if environment_session.is_some() || environment_socket.is_some() {
+                return true;
+            }
+            session == "default"
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HerdrClientSession<'a> {
+    Default,
+    Named(&'a str),
+}
+
+fn interactive_herdr_session(command: &[String]) -> Option<HerdrClientSession<'_>> {
     let is_herdr = command
         .first()
         .and_then(|value| Path::new(value).file_name())
         .is_some_and(|name| name == "herdr");
     if !is_herdr {
-        return false;
+        return None;
+    }
+    if let [_, session, attach, name] = command
+        && session == "session"
+        && attach == "attach"
+        && !name.is_empty()
+    {
+        return Some(HerdrClientSession::Named(name));
     }
 
-    let session_argument = command
-        .windows(2)
-        .any(|pair| pair[0] == "--session" && pair[1] == session);
-    let session_environment = environment
-        .iter()
-        .any(|value| value == &format!("HERDR_SESSION={session}"));
-    let socket_environment = environment
-        .iter()
-        .any(|value| value == &format!("HERDR_SOCKET_PATH={}", socket_path.to_string_lossy()));
-
-    if session != "default" {
-        return session_argument || session_environment || socket_environment;
+    let mut named = None;
+    let mut index = 1;
+    while index < command.len() {
+        let argument = &command[index];
+        if argument == "--handoff" {
+            index += 1;
+            continue;
+        }
+        if argument == "--session" {
+            let value = command.get(index + 1)?;
+            if value.is_empty() || named.replace(value.as_str()).is_some() {
+                return None;
+            }
+            index += 2;
+            continue;
+        }
+        if let Some(value) = argument.strip_prefix("--session=") {
+            if value.is_empty() || named.replace(value).is_some() {
+                return None;
+            }
+            index += 1;
+            continue;
+        }
+        // All positional tokens are CLI subcommands, while remote/no-session
+        // and informational flags do not host the local persistent session.
+        return None;
     }
-    let names_other_session = command.iter().any(|value| value == "--session")
-        || environment
-            .iter()
-            .any(|value| value.starts_with("HERDR_SESSION="))
-        || environment
-            .iter()
-            .any(|value| value.starts_with("HERDR_SOCKET_PATH=") && !socket_environment);
-    !names_other_session || session_argument || session_environment || socket_environment
+    Some(named.map_or(HerdrClientSession::Default, HerdrClientSession::Named))
 }
 
 #[cfg(test)]
@@ -528,6 +655,52 @@ mod tests {
             &[],
             "work",
             Path::new("/tmp/work.sock")
+        ));
+        assert!(command_matches_session(
+            &[
+                "herdr".into(),
+                "session".into(),
+                "attach".into(),
+                "work".into()
+            ],
+            &[],
+            "work",
+            Path::new("/tmp/work.sock")
+        ));
+        assert!(!command_matches_session(
+            &[
+                "herdr".into(),
+                "session".into(),
+                "attach".into(),
+                "work".into()
+            ],
+            &[],
+            "default",
+            Path::new("/tmp/default.sock")
+        ));
+        assert!(!command_matches_session(
+            &["herdr".into(), "--session".into(), "work".into()],
+            &["HERDR_SESSION=default".into()],
+            "default",
+            Path::new("/tmp/default.sock")
+        ));
+        assert!(!command_matches_session(
+            &["herdr".into(), "--session".into(), "work".into()],
+            &["HERDR_SESSION=default".into()],
+            "work",
+            Path::new("/tmp/work.sock")
+        ));
+        assert!(command_matches_session(
+            &["herdr".into(), "--session".into(), "work".into()],
+            &["HERDR_SOCKET_PATH=/tmp/default.sock".into()],
+            "work",
+            Path::new("/tmp/work.sock")
+        ));
+        assert!(!command_matches_session(
+            &["herdr".into(), "--session".into(), "work".into()],
+            &["HERDR_SOCKET_PATH=/tmp/default.sock".into()],
+            "default",
+            Path::new("/tmp/default.sock")
         ));
     }
 
@@ -551,6 +724,224 @@ mod tests {
             "default",
             Path::new("/tmp/default.sock")
         ));
+    }
+
+    #[test]
+    fn only_interactive_herdr_clients_can_host_a_session() {
+        for command in [
+            vec!["herdr", "agent", "wait", "reviewer"],
+            vec!["herdr", "status"],
+            vec!["herdr", "api", "state"],
+            vec!["herdr", "workspace", "list"],
+            vec!["herdr", "update"],
+            vec!["herdr", "server"],
+            vec!["herdr", "--remote", "host"],
+            vec!["herdr", "--no-session"],
+            vec!["herdr", "--skill"],
+        ] {
+            assert!(
+                !command_matches_session(
+                    &command.into_iter().map(String::from).collect::<Vec<_>>(),
+                    &[],
+                    "default",
+                    Path::new("/tmp/default.sock")
+                ),
+                "CLI command must not claim the compositor client"
+            );
+        }
+        assert!(command_matches_session(
+            &["herdr".into(), "--handoff".into()],
+            &[],
+            "default",
+            Path::new("/tmp/default.sock")
+        ));
+        assert!(command_matches_session(
+            &["herdr".into(), "--session=work".into(), "--handoff".into()],
+            &[],
+            "work",
+            Path::new("/tmp/work.sock")
+        ));
+    }
+
+    #[test]
+    fn terminal_hosted_herdr_uses_most_recent_exact_session_window() {
+        let clients: Vec<HyprClient> = serde_json::from_str(
+            r#"[
+                {"address":"0xold","class":"kitty","initialClass":"kitty","title":"older workspace","initialTitle":"kitty","pid":100,"monitor":0,"focusHistoryID":7},
+                {"address":"0xnew","class":"kitty","initialClass":"kitty","title":"current workspace","initialTitle":"kitty","pid":200,"monitor":0,"focusHistoryID":1},
+                {"address":"0xother","class":"kitty","initialClass":"kitty","title":"shell","initialTitle":"kitty","pid":300,"monitor":0,"focusHistoryID":2},
+                {"address":"0xcli","class":"kitty","initialClass":"kitty","title":"recent CLI terminal","initialTitle":"kitty","pid":400,"monitor":0,"focusHistoryID":0}
+            ]"#,
+        )
+        .unwrap();
+        let processes = HashMap::from([
+            (
+                101,
+                ProcessInfo {
+                    parent: 100,
+                    command: vec!["herdr".into()],
+                    environment: vec![],
+                },
+            ),
+            (
+                201,
+                ProcessInfo {
+                    parent: 200,
+                    command: vec!["/home/user/.local/bin/herdr".into()],
+                    environment: vec![],
+                },
+            ),
+            (
+                301,
+                ProcessInfo {
+                    parent: 300,
+                    command: vec!["bash".into()],
+                    environment: vec![],
+                },
+            ),
+            (
+                401,
+                ProcessInfo {
+                    parent: 400,
+                    command: vec![
+                        "herdr".into(),
+                        "agent".into(),
+                        "wait".into(),
+                        "reviewer".into(),
+                    ],
+                    environment: vec![],
+                },
+            ),
+        ]);
+
+        let selected = select_herdr_candidate(
+            &clients,
+            &processes,
+            "default",
+            Path::new("/tmp/default.sock"),
+            "herdr",
+        )
+        .unwrap();
+        assert_eq!(selected.address, "0xnew");
+    }
+
+    #[test]
+    fn herdr_window_selection_prefers_native_identity_hint() {
+        let clients: Vec<HyprClient> = serde_json::from_str(
+            r#"[
+                {"address":"0xterminal","class":"kitty","initialClass":"kitty","title":"workspace","initialTitle":"kitty","pid":100,"monitor":0,"focusHistoryID":0},
+                {"address":"0xnative","class":"Herdr","initialClass":"Herdr","title":"Herdr","initialTitle":"Herdr","pid":200,"monitor":0,"focusHistoryID":4}
+            ]"#,
+        )
+        .unwrap();
+        let processes = HashMap::from([
+            (
+                101,
+                ProcessInfo {
+                    parent: 100,
+                    command: vec!["herdr".into()],
+                    environment: vec![],
+                },
+            ),
+            (
+                201,
+                ProcessInfo {
+                    parent: 200,
+                    command: vec!["herdr".into()],
+                    environment: vec![],
+                },
+            ),
+        ]);
+
+        let selected = select_herdr_candidate(
+            &clients,
+            &processes,
+            "default",
+            Path::new("/tmp/default.sock"),
+            "herdr",
+        )
+        .unwrap();
+        assert_eq!(selected.address, "0xnative");
+    }
+
+    #[test]
+    fn herdr_window_selection_fails_closed_on_tied_focus_history() {
+        let clients: Vec<HyprClient> = serde_json::from_str(
+            r#"[
+                {"address":"0x1","class":"kitty","initialClass":"kitty","title":"one","initialTitle":"kitty","pid":100,"monitor":0,"focusHistoryID":0},
+                {"address":"0x2","class":"kitty","initialClass":"kitty","title":"two","initialTitle":"kitty","pid":200,"monitor":0,"focusHistoryID":0}
+            ]"#,
+        )
+        .unwrap();
+        let processes = HashMap::from([
+            (
+                101,
+                ProcessInfo {
+                    parent: 100,
+                    command: vec!["herdr".into()],
+                    environment: vec![],
+                },
+            ),
+            (
+                201,
+                ProcessInfo {
+                    parent: 200,
+                    command: vec!["herdr".into()],
+                    environment: vec![],
+                },
+            ),
+        ]);
+
+        assert!(
+            select_herdr_candidate(
+                &clients,
+                &processes,
+                "default",
+                Path::new("/tmp/default.sock"),
+                "herdr",
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn herdr_window_selection_fails_closed_on_partial_focus_history() {
+        let clients: Vec<HyprClient> = serde_json::from_str(
+            r#"[
+                {"address":"0x1","class":"kitty","initialClass":"kitty","title":"one","initialTitle":"kitty","pid":100,"monitor":0},
+                {"address":"0x2","class":"kitty","initialClass":"kitty","title":"two","initialTitle":"kitty","pid":200,"monitor":0,"focusHistoryID":0}
+            ]"#,
+        )
+        .unwrap();
+        let processes = HashMap::from([
+            (
+                101,
+                ProcessInfo {
+                    parent: 100,
+                    command: vec!["herdr".into()],
+                    environment: vec![],
+                },
+            ),
+            (
+                201,
+                ProcessInfo {
+                    parent: 200,
+                    command: vec!["herdr".into()],
+                    environment: vec![],
+                },
+            ),
+        ]);
+
+        assert!(
+            select_herdr_candidate(
+                &clients,
+                &processes,
+                "default",
+                Path::new("/tmp/default.sock"),
+                "herdr",
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -596,6 +987,19 @@ mod tests {
             r#"[
                 {"address":"0x1","class":"chatgpt","initialClass":"chatgpt","title":"Thread A","initialTitle":"ChatGPT","pid":1,"monitor":0,"floating":false},
                 {"address":"0x2","class":"chatgpt","initialClass":"chatgpt","title":"Thread B","initialTitle":"ChatGPT","pid":2,"monitor":0,"floating":false}
+            ]"#,
+        )
+        .unwrap();
+
+        assert!(select_desktop_candidate(&clients, desktop_app_spec(DesktopApp::ChatGpt)).is_err());
+    }
+
+    #[test]
+    fn desktop_candidate_fails_closed_on_partial_focus_history() {
+        let clients: Vec<HyprClient> = serde_json::from_str(
+            r#"[
+                {"address":"0x1","class":"chatgpt","initialClass":"chatgpt","title":"Thread A","initialTitle":"ChatGPT","pid":1,"monitor":0,"floating":false},
+                {"address":"0x2","class":"chatgpt","initialClass":"chatgpt","title":"Thread B","initialTitle":"ChatGPT","pid":2,"monitor":0,"floating":false,"focusHistoryID":0}
             ]"#,
         )
         .unwrap();

--- a/crates/xeneon-agent-core/src/runtime.rs
+++ b/crates/xeneon-agent-core/src/runtime.rs
@@ -677,6 +677,13 @@ impl DaemonRuntime {
             .await
         {
             Ok(()) => {
+                if command.action == ActionKind::Open {
+                    self.acknowledge_review_ready(&agent.id).await;
+                }
+                // Herdr already committed the focus/zoom operation. Refresh
+                // authoritative state even if compositor activation then
+                // fails, so the portal never retains a stale review badge.
+                let _ = self.invalidations.try_send(target.session.clone());
                 if matches!(command.action, ActionKind::Open | ActionKind::Zoom)
                     && let Err(error) = self
                         .desktop
@@ -690,10 +697,6 @@ impl DaemonRuntime {
                         "agent focused, but its Herdr window was not activated",
                     );
                 }
-                if command.action == ActionKind::Open {
-                    self.acknowledge_review_ready(&agent.id).await;
-                }
-                let _ = self.invalidations.try_send(target.session);
                 action_ok(&command.request_id, "action_completed")
             }
             Err(error) => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,9 +124,12 @@ window the transcription target.
 The production QML process creates no window unless one configured output
 identity matches. It does not use a primary-screen fallback.
 
-Hyprland activation is session-specific. The daemon considers only compositor
-clients whose process trees contain the exact Herdr session or socket identity;
-ambiguous matches fail instead of focusing a generic window title.
+Hyprland activation is session-specific. Exact interactive Herdr
+process/session ownership is authoritative; transient Herdr CLI commands and
+unrelated terminals are excluded. A configured native class/title is only a
+preference among owning clients. When multiple terminal-hosted views remain,
+the unique most-recent Hyprland focus-history entry is selected; missing or
+tied history fails closed.
 
 ChatGPT Desktop and Claude Desktop use separate fixed action kinds. The daemon
 matches exact known compositor classes: one match is focused, no match launches

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,9 +130,12 @@ ambiguous matches fail instead of focusing a generic window title.
 
 ChatGPT Desktop and Claude Desktop use separate fixed action kinds. The daemon
 matches exact known compositor classes: one match is focused, no match launches
-the corresponding fixed desktop entry through `uwsm-app`, and multiple matches
-fail closed. Launches are coalesced per app while the daemon waits a bounded
-time for exactly one mapped client, then focuses it before reporting success.
+the corresponding fixed desktop entry through an `uwsm app` graphical service,
+and multiple matches are narrowed by the known initial main title, tiled state,
+and unique most-recent focus-history entry before failing closed. Launches are
+coalesced per app while the daemon waits a bounded time for a mapped client,
+then focuses it before reporting success; every observation failure clears the
+coalescing state.
 QML cannot choose an executable, desktop entry, class, title, or arguments.
 
 Passive EDGE gestures may request restoration of the last observed non-EDGE

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -150,6 +150,12 @@ class, or argument from QML. When an exact class has multiple windows, the
 daemon narrows to the known initial main title, a tiled window, and then the uniquely
 most-recent focus-history entry; a match still ambiguous after those checks
 fails closed.
+Herdr activation separately requires an interactive Herdr process with the
+exact requested session identity in the compositor client's process tree;
+transient Herdr CLI commands cannot claim a terminal. A configured native
+class/title is preferred when present, otherwise multiple owning terminal
+views narrow to the unique most-recent focus-history entry and fail closed on
+missing or tied history.
 Voice actions are single-attempt operations and return only
 bounded static result messages. Host commands have a ten-second ceiling; a
 failed or timed-out start may issue one distinct cancel cleanup attempt but is

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -146,7 +146,10 @@ The only actions are:
 
 There is no method, key, text, shell-command, prompt, close, or server-control
 passthrough. Desktop actions do not accept a desktop ID, executable, title,
-class, or argument from QML, and ambiguous compositor matches fail closed.
+class, or argument from QML. When an exact class has multiple windows, the
+daemon narrows to the known initial main title, a tiled window, and then the uniquely
+most-recent focus-history entry; a match still ambiguous after those checks
+fails closed.
 Voice actions are single-attempt operations and return only
 bounded static result messages. Host commands have a ten-second ceiling; a
 failed or timed-out start may issue one distinct cancel cleanup attempt but is

--- a/quickshell/components/PortalView.qml
+++ b/quickshell/components/PortalView.qml
@@ -404,88 +404,123 @@ Item {
             }
         }
 
-        Rectangle {
-            id: agentOrderToggle
-            objectName: "agentOrderToggle"
-
+        Row {
+            id: headerActions
+            objectName: "headerActions"
             anchors {
                 left: headerIdentity.right
                 leftMargin: 44
                 verticalCenter: parent.verticalCenter
             }
-            width: 184
-            height: 48
-            radius: 12
-            color: orderTap.pressed
-                ? root.theme.surfacePressed
-                : root.theme.surfaceRaised
-            border.width: 1
-            border.color: root.agentOrderAvailable
-                ? root.theme.accent
-                : root.theme.border
-            enabled: root.controlCenterInteractive
-                && root.agentOrderAvailable
-                && root.pendingAgentOrderRequest === ""
+            spacing: 12
 
-            function activate() {
-                if (!enabled)
-                    return false
-                root.activity.noteUserActivity()
-                return root.requestAgentOrder(
-                    root.agentOrderMode === "grouped"
-                        ? "priority"
-                        : "grouped"
-                )
-            }
+            Rectangle {
+                id: agentOrderToggle
+                objectName: "agentOrderToggle"
 
-            Accessible.role: Accessible.Button
-            // Disabled status is still meaningful: expose why synchronization
-            // is unavailable or currently in progress to assistive technology.
-            Accessible.ignored: false
-            Accessible.name: root.pendingAgentOrderRequest !== ""
-                ? "Agent ordering syncing"
-                : root.agentOrderAvailable
-                    ? "Agent ordering " + root.agentOrderMode
-                    : "Agent ordering unavailable"
-            Accessible.description: root.pendingAgentOrderRequest !== ""
-                ? "Synchronizing agent ordering with Herdr"
-                : root.agentOrderAvailable
-                    ? "Switch Herdr and the command center to "
-                    + (root.agentOrderMode === "grouped"
-                        ? "priority"
-                        : "grouped") + " ordering"
-                    : "Requires a Herdr version with agent ordering API support"
-            Accessible.onPressAction: activate()
+                width: 184
+                height: 48
+                radius: 12
+                color: orderTap.pressed
+                    ? root.theme.surfacePressed
+                    : root.theme.surfaceRaised
+                border.width: 1
+                border.color: root.agentOrderAvailable
+                    ? root.theme.accent
+                    : root.theme.border
+                enabled: root.controlCenterInteractive
+                    && root.agentOrderAvailable
+                    && root.pendingAgentOrderRequest === ""
 
-            Text {
-                objectName: "agentOrderLabel"
-                anchors.centerIn: parent
-                text: root.pendingAgentOrderRequest !== ""
-                    ? "ORDER // SYNCING"
+                function activate() {
+                    if (!enabled)
+                        return false
+                    root.activity.noteUserActivity()
+                    return root.requestAgentOrder(
+                        root.agentOrderMode === "grouped"
+                            ? "priority"
+                            : "grouped"
+                    )
+                }
+
+                Accessible.role: Accessible.Button
+                // Disabled status is still meaningful: expose why synchronization
+                // is unavailable or currently in progress to assistive technology.
+                Accessible.ignored: false
+                Accessible.name: root.pendingAgentOrderRequest !== ""
+                    ? "Agent ordering syncing"
                     : root.agentOrderAvailable
-                        ? "ORDER // " + root.agentOrderMode.toUpperCase()
-                        : "ORDER // UNAVAILABLE"
-                textFormat: Text.PlainText
-                color: root.agentOrderAvailable
-                    ? root.theme.textPrimary
-                    : root.theme.textMuted
-                font {
-                    family: "monospace"
-                    pixelSize: 11
-                    weight: Font.DemiBold
-                    letterSpacing: 0.5
+                        ? "Agent ordering " + root.agentOrderMode
+                        : "Agent ordering unavailable"
+                Accessible.description: root.pendingAgentOrderRequest !== ""
+                    ? "Synchronizing agent ordering with Herdr"
+                    : root.agentOrderAvailable
+                        ? "Switch Herdr and the command center to "
+                        + (root.agentOrderMode === "grouped"
+                            ? "priority"
+                            : "grouped") + " ordering"
+                        : "Requires a Herdr version with agent ordering API support"
+                Accessible.onPressAction: activate()
+
+                Text {
+                    objectName: "agentOrderLabel"
+                    anchors.centerIn: parent
+                    text: root.pendingAgentOrderRequest !== ""
+                        ? "ORDER // SYNCING"
+                        : root.agentOrderAvailable
+                            ? "ORDER // " + root.agentOrderMode.toUpperCase()
+                            : "ORDER // UNAVAILABLE"
+                    textFormat: Text.PlainText
+                    color: root.agentOrderAvailable
+                        ? root.theme.textPrimary
+                        : root.theme.textMuted
+                    font {
+                        family: "monospace"
+                        pixelSize: 11
+                        weight: Font.DemiBold
+                        letterSpacing: 0.5
+                    }
+                }
+
+                TapHandler {
+                    id: orderTap
+                    gesturePolicy: TapHandler.ReleaseWithinBounds
+                    onTapped: agentOrderToggle.activate()
                 }
             }
 
-            TapHandler {
-                id: orderTap
-                gesturePolicy: TapHandler.ReleaseWithinBounds
-                onTapped: agentOrderToggle.activate()
+            DesktopAppButton {
+                objectName: "chatGptDesktopButton"
+                width: 132
+                height: 48
+                label: "CHATGPT"
+                accent: root.theme.green
+                theme: root.theme
+                pending: root.desktopActionPending("chatgpt_desktop")
+                enabled: root.controlCenterInteractive
+                    && !root.store.freshSnapshotRequired
+                onInteracted: root.activity.noteUserActivity()
+                onTriggered: root.requestDesktop("chatgpt_desktop")
+            }
+
+            DesktopAppButton {
+                objectName: "claudeDesktopButton"
+                width: 132
+                height: 48
+                label: "CLAUDE"
+                accent: root.theme.orange
+                theme: root.theme
+                pending: root.desktopActionPending("claude_desktop")
+                enabled: root.controlCenterInteractive
+                    && !root.store.freshSnapshotRequired
+                onInteracted: root.activity.noteUserActivity()
+                onTriggered: root.requestDesktop("claude_desktop")
             }
         }
 
         Row {
             id: pageDots
+            objectName: "pageDots"
 
             anchors.centerIn: parent
             spacing: 12
@@ -547,34 +582,6 @@ Item {
                 rightMargin: displaySettings.width + 16
             }
             spacing: 12
-
-            DesktopAppButton {
-                width: 188
-                height: 58
-                anchors.verticalCenter: parent.verticalCenter
-                label: "CHATGPT"
-                accent: root.theme.green
-                theme: root.theme
-                pending: root.desktopActionPending("chatgpt_desktop")
-                enabled: root.controlCenterInteractive
-                    && !root.store.freshSnapshotRequired
-                onInteracted: root.activity.noteUserActivity()
-                onTriggered: root.requestDesktop("chatgpt_desktop")
-            }
-
-            DesktopAppButton {
-                width: 188
-                height: 58
-                anchors.verticalCenter: parent.verticalCenter
-                label: "CLAUDE"
-                accent: root.theme.orange
-                theme: root.theme
-                pending: root.desktopActionPending("claude_desktop")
-                enabled: root.controlCenterInteractive
-                    && !root.store.freshSnapshotRequired
-                onInteracted: root.activity.noteUserActivity()
-                onTriggered: root.requestDesktop("claude_desktop")
-            }
 
             VoiceControl {
                 width: 320

--- a/quickshell/tests/tst_portal_layout.qml
+++ b/quickshell/tests/tst_portal_layout.qml
@@ -44,13 +44,21 @@ TestCase {
         property bool ready: true
         property int orderRequests: 0
         property string lastOrder: ""
+        property int chatGptRequests: 0
+        property int claudeRequests: 0
 
         function restoreFocus() { return "restore" }
         function openAgent(agentId) { return agentId }
         function approveAgent() { return "approve" }
         function interruptAgent() { return "interrupt" }
-        function openChatGptDesktop() { return "chatgpt" }
-        function openClaudeDesktop() { return "claude" }
+        function openChatGptDesktop() {
+            chatGptRequests += 1
+            return "chatgpt-" + chatGptRequests
+        }
+        function openClaudeDesktop() {
+            claudeRequests += 1
+            return "claude-" + claudeRequests
+        }
         function startVoice() { return "voice-start" }
         function stopVoice() { return "voice-stop" }
         function cancelVoice() { return "voice-cancel" }
@@ -138,6 +146,9 @@ TestCase {
         mockStore.testSurfaceState = ""
         mockBridge.orderRequests = 0
         mockBridge.lastOrder = ""
+        mockBridge.chatGptRequests = 0
+        mockBridge.claudeRequests = 0
+        portal.pendingDesktopActions = ({})
         portal.pendingAgentOrderRequest = ""
         portal.paletteSettingsOpen = false
         mockPreferences.readyColorRole = "muted"
@@ -236,6 +247,55 @@ TestCase {
         verify(toggle.activate())
         compare(mockBridge.orderRequests, 2)
         compare(mockBridge.lastOrder, "grouped")
+    }
+
+    function test_desktopLaunchersSitImmediatelyAfterOrderWithoutOverlap() {
+        var actions = findChild(portal, "headerActions")
+        var order = findChild(portal, "agentOrderToggle")
+        var chatGpt = findChild(portal, "chatGptDesktopButton")
+        var claude = findChild(portal, "claudeDesktopButton")
+        var dots = findChild(portal, "pageDots")
+        verify(actions !== null)
+        verify(order !== null)
+        verify(chatGpt !== null)
+        verify(claude !== null)
+        verify(dots !== null)
+
+        compare(chatGpt.x, order.x + order.width + actions.spacing)
+        compare(claude.x, chatGpt.x + chatGpt.width + actions.spacing)
+        verify(actions.x + actions.width < dots.x)
+        compare(chatGpt.Accessible.name, "CHATGPT")
+        compare(claude.Accessible.name, "CLAUDE")
+        verify(chatGpt.enabled)
+        verify(claude.enabled)
+
+        verify(chatGpt.activate())
+        compare(mockBridge.chatGptRequests, 1)
+        compare(mockBridge.claudeRequests, 0)
+        verify(chatGpt.pending)
+        verify(!chatGpt.activate())
+        compare(mockBridge.chatGptRequests, 1)
+        mockStore.actionResultReceived({
+            "request_id": "chatgpt-1",
+            "action": "chatgpt_desktop",
+            "ok": true,
+            "code": "desktop_ready",
+            "message": "desktop_ready"
+        })
+        verify(!chatGpt.pending)
+
+        verify(claude.activate())
+        compare(mockBridge.chatGptRequests, 1)
+        compare(mockBridge.claudeRequests, 1)
+        verify(claude.pending)
+        mockStore.actionResultReceived({
+            "request_id": "claude-1",
+            "action": "claude_desktop",
+            "ok": false,
+            "code": "desktop_launch_failed",
+            "message": "desktop_launch_failed"
+        })
+        verify(!claude.pending)
     }
 
     function test_lowerCountsAndShrinkClampSafely() {


### PR DESCRIPTION
## What changed

- place ChatGPT and Claude launch controls beside the authoritative Herdr order control and use the installed desktop identities
- make Herdr compositor activation work for terminal-hosted clients without trusting generic terminal titles
- select only interactive clients with the exact session identity, exclude transient Herdr CLI processes, and fail closed on incomplete or ambiguous focus history
- refresh authoritative agent state even when compositor activation fails after Herdr accepted the action
- document the session-owned window selection boundary

## Root cause

Herdr 0.8.0 is hosted inside Kitty, so Hyprland exposes the window as class `kitty`, not `herdr`. The adapter required a Herdr class/title before checking process ownership and therefore found zero windows even though Herdr had already focused the requested agent. Two valid views of the default session also required deterministic, fail-closed selection.

## Validation

- independent Claude review loop: final GO, no P0-P2
- 87 Rust core tests plus the CLI test
- strict workspace Clippy and rustfmt
- 27 Python and 113 Qt QML tests
- all 31 installer integration scenarios
- ShellCheck, `luac -p`, and `git diff --check`
- hosted CI: Rust, QML, and integration-contracts passed

## Live validation

The reviewed release binaries are installed with exact artifact hashes. The reconnected physical XENEON touchscreen triggered the fail-closed lifecycle successfully; agentd and the portal are active with zero restarts, Herdr is connected with 20 agents, Hyprland reports no config errors, and the owner completed the physical focus review.